### PR TITLE
Add minimal CLI for identity and relay messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +50,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +69,16 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.2.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -112,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -193,6 +224,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +268,31 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+
+[[package]]
+name = "flate2"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "generic-array"
@@ -317,6 +384,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,10 +495,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -346,6 +555,12 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "poly1305"
@@ -368,6 +583,15 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -437,12 +661,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -465,6 +738,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +790,30 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "subtle"
@@ -493,14 +833,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tenet-crypto"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "chacha20poly1305",
  "hex",
  "hpke",
  "rand",
  "rand_chacha",
+ "serde",
+ "serde_json",
+ "sha2",
+ "ureq",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -526,6 +892,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +944,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.5",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +1048,29 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -568,6 +1094,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,3 +1133,42 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+base64 = "0.22"
 chacha20poly1305 = { version = "0.10", features = ["std"] }
+hex = "0.4"
 hpke = "0.11"
 rand = "0.8"
 rand_chacha = "0.3"
-
-[dev-dependencies]
-hex = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = "0.10"
+ureq = { version = "2.10", features = ["tls"] }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -6,6 +6,7 @@ use hpke::kem::X25519HkdfSha256;
 use hpke::{Deserializable, OpModeR, OpModeS, Serializable};
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
+use std::fmt;
 
 pub const CONTENT_KEY_SIZE: usize = 32;
 pub const NONCE_SIZE: usize = 12;
@@ -22,6 +23,18 @@ pub enum CryptoError {
     Hpke(hpke::HpkeError),
     Aead(chacha20poly1305::aead::Error),
 }
+
+impl fmt::Display for CryptoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CryptoError::InvalidLength(message) => write!(f, "invalid length: {message}"),
+            CryptoError::Hpke(error) => write!(f, "hpke error: {error}"),
+            CryptoError::Aead(error) => write!(f, "aead error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for CryptoError {}
 
 impl From<hpke::HpkeError> for CryptoError {
     fn from(error: hpke::HpkeError) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,402 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use hpke::kem::X25519HkdfSha256;
+use hpke::{Kem as _, Serializable};
+use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use tenet_crypto::crypto::{
+    decrypt_payload, encrypt_payload, generate_content_key, wrap_content_key, WrappedKey,
+};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Identity {
+    id: String,
+    public_key_hex: String,
+    private_key_hex: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Peer {
+    name: String,
+    id: String,
+    public_key_hex: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Header {
+    sender_id: String,
+    recipient_id: String,
+    timestamp: u64,
+    content_type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct WrappedKeyData {
+    enc_hex: String,
+    ciphertext_hex: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EncryptedPayload {
+    nonce_hex: String,
+    ciphertext_hex: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Envelope {
+    message_id: String,
+    header: Header,
+    wrapped_key: WrappedKeyData,
+    payload: EncryptedPayload,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ReceivedMessage {
+    sender_id: String,
+    timestamp: u64,
+    message: String,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut args = env::args().collect::<Vec<String>>();
+    if args.len() < 2 {
+        print_usage();
+        return Ok(());
+    }
+
+    let command = args[1].clone();
+    let command_args = args.split_off(2);
+
+    match command.as_str() {
+        "init" => init_identity(),
+        "add-peer" => add_peer(&command_args),
+        "send" => send_message(&command_args),
+        "sync" => sync_messages(&command_args),
+        _ => {
+            print_usage();
+            Ok(())
+        }
+    }
+}
+
+fn print_usage() {
+    println!(
+        "tenet-cli commands:\n\
+         \n\
+         init\n\
+         add-peer <name> <public_key_hex>\n\
+         send <peer_name> <message> [--relay <url>]\n\
+         sync [--relay <url>]\n\
+         \n\
+         Environment:\n\
+         TENET_HOME defaults to .tenet\n\
+         TENET_RELAY_URL provides a relay URL default for send/sync"
+    );
+}
+
+fn data_dir() -> PathBuf {
+    env::var("TENET_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(".tenet"))
+}
+
+fn ensure_dir(path: &Path) -> Result<(), Box<dyn Error>> {
+    if !path.exists() {
+        fs::create_dir_all(path)?;
+    }
+    Ok(())
+}
+
+fn identity_path() -> PathBuf {
+    data_dir().join("identity.json")
+}
+
+fn peers_path() -> PathBuf {
+    data_dir().join("peers.json")
+}
+
+fn outbox_path() -> PathBuf {
+    data_dir().join("outbox.jsonl")
+}
+
+fn inbox_path() -> PathBuf {
+    data_dir().join("inbox.jsonl")
+}
+
+fn init_identity() -> Result<(), Box<dyn Error>> {
+    let dir = data_dir();
+    ensure_dir(&dir)?;
+    let identity_file = identity_path();
+
+    if identity_file.exists() {
+        let identity = load_identity()?;
+        println!("identity already exists: {}", identity.id);
+        return Ok(());
+    }
+
+    let mut rng = OsRng;
+    let (private_key, public_key) = X25519HkdfSha256::gen_keypair(&mut rng);
+    let public_key_bytes = public_key.to_bytes();
+    let private_key_bytes = private_key.to_bytes();
+    let id = content_id_from_bytes(&public_key_bytes);
+
+    let identity = Identity {
+        id,
+        public_key_hex: hex::encode(public_key_bytes),
+        private_key_hex: hex::encode(private_key_bytes),
+    };
+
+    let json = serde_json::to_string_pretty(&identity)?;
+    fs::write(&identity_file, json)?;
+    println!("identity created: {}", identity.id);
+    Ok(())
+}
+
+fn load_identity() -> Result<Identity, Box<dyn Error>> {
+    let data = fs::read_to_string(identity_path())?;
+    Ok(serde_json::from_str(&data)?)
+}
+
+fn load_peers() -> Result<Vec<Peer>, Box<dyn Error>> {
+    let path = peers_path();
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let data = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&data)?)
+}
+
+fn save_peers(peers: &[Peer]) -> Result<(), Box<dyn Error>> {
+    let json = serde_json::to_string_pretty(peers)?;
+    fs::write(peers_path(), json)?;
+    Ok(())
+}
+
+fn add_peer(args: &[String]) -> Result<(), Box<dyn Error>> {
+    if args.len() < 2 {
+        return Err("add-peer requires <name> <public_key_hex>".into());
+    }
+
+    ensure_dir(&data_dir())?;
+
+    let name = args[0].clone();
+    let public_key_hex = args[1].clone();
+    let public_key_bytes = hex::decode(&public_key_hex)?;
+    let id = content_id_from_bytes(&public_key_bytes);
+
+    let mut peers = load_peers()?;
+    if let Some(existing) = peers.iter_mut().find(|peer| peer.name == name) {
+        existing.public_key_hex = public_key_hex;
+        existing.id = id.clone();
+    } else {
+        peers.push(Peer {
+            name: name.clone(),
+            id: id.clone(),
+            public_key_hex,
+        });
+    }
+
+    save_peers(&peers)?;
+    println!("peer saved: {} ({})", name, id);
+    Ok(())
+}
+
+fn send_message(args: &[String]) -> Result<(), Box<dyn Error>> {
+    let mut relay_url = env::var("TENET_RELAY_URL").ok();
+    let mut peer_name: Option<String> = None;
+    let mut message_parts: Vec<String> = Vec::new();
+
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--relay" => {
+                index += 1;
+                if index >= args.len() {
+                    return Err("--relay requires a URL".into());
+                }
+                relay_url = Some(args[index].clone());
+            }
+            value => {
+                if peer_name.is_none() {
+                    peer_name = Some(value.to_string());
+                } else {
+                    message_parts.push(value.to_string());
+                }
+            }
+        }
+        index += 1;
+    }
+
+    let relay_url = relay_url.ok_or("relay URL required (use --relay or TENET_RELAY_URL)")?;
+    let peer_name = peer_name.ok_or("send requires <peer_name>")?;
+    let message = message_parts.join(" ");
+    if message.trim().is_empty() {
+        return Err("send requires a message".into());
+    }
+
+    let identity = load_identity()?;
+    let peers = load_peers()?;
+    let peer = peers
+        .iter()
+        .find(|peer| peer.name == peer_name)
+        .ok_or("peer not found")?;
+
+    let timestamp = current_timestamp()?;
+    let header = Header {
+        sender_id: identity.id.clone(),
+        recipient_id: peer.id.clone(),
+        timestamp,
+        content_type: "text/plain".to_string(),
+    };
+    let aad = serde_json::to_vec(&header)?;
+
+    let content_key = generate_content_key();
+    let (nonce, ciphertext) = encrypt_payload(&content_key, message.as_bytes(), &aad, None)?;
+    let wrapped = wrap_content_key(
+        &hex::decode(&peer.public_key_hex)?,
+        &content_key,
+        b"tenet-cli",
+        None,
+    )?;
+
+    let payload = EncryptedPayload {
+        nonce_hex: hex::encode(nonce),
+        ciphertext_hex: hex::encode(ciphertext),
+    };
+
+    let message_id = build_message_id(&header, &payload)?;
+
+    let envelope = Envelope {
+        message_id,
+        header,
+        wrapped_key: WrappedKeyData {
+            enc_hex: hex::encode(wrapped.enc),
+            ciphertext_hex: hex::encode(wrapped.ciphertext),
+        },
+        payload,
+    };
+
+    let body = serde_json::to_string(&envelope)?;
+    append_json_line(outbox_path(), &envelope)?;
+
+    let response = ureq::post(&format!("{}/envelopes", relay_url))
+        .set("Content-Type", "application/json")
+        .send_string(&body)?;
+
+    if response.status() >= 400 {
+        return Err(format!("relay returned status {}", response.status()).into());
+    }
+
+    println!("sent message {} to {}", envelope.message_id, peer.name);
+    Ok(())
+}
+
+fn sync_messages(args: &[String]) -> Result<(), Box<dyn Error>> {
+    let mut relay_url = env::var("TENET_RELAY_URL").ok();
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--relay" => {
+                index += 1;
+                if index >= args.len() {
+                    return Err("--relay requires a URL".into());
+                }
+                relay_url = Some(args[index].clone());
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    let relay_url = relay_url.ok_or("relay URL required (use --relay or TENET_RELAY_URL)")?;
+    let identity = load_identity()?;
+    let response = ureq::get(&format!("{}/inbox/{}", relay_url, identity.id)).call()?;
+    let body = response.into_string()?;
+    if body.trim().is_empty() {
+        println!("no envelopes available");
+        return Ok(());
+    }
+
+    let envelopes: Vec<Envelope> = serde_json::from_str(&body)?;
+    let mut received = 0;
+
+    for envelope in envelopes {
+        if envelope.header.recipient_id != identity.id {
+            continue;
+        }
+
+        let plaintext = decrypt_envelope(&identity, &envelope)?;
+        let message = String::from_utf8_lossy(&plaintext);
+        println!("from {}: {}", envelope.header.sender_id, message);
+
+        let record = ReceivedMessage {
+            sender_id: envelope.header.sender_id.clone(),
+            timestamp: envelope.header.timestamp,
+            message: message.to_string(),
+        };
+        append_json_line(inbox_path(), &record)?;
+        received += 1;
+    }
+
+    println!("synced {} envelopes", received);
+    Ok(())
+}
+
+fn decrypt_envelope(identity: &Identity, envelope: &Envelope) -> Result<Vec<u8>, Box<dyn Error>> {
+    let aad = serde_json::to_vec(&envelope.header)?;
+    let wrapped = WrappedKey {
+        enc: hex::decode(&envelope.wrapped_key.enc_hex)?,
+        ciphertext: hex::decode(&envelope.wrapped_key.ciphertext_hex)?,
+    };
+
+    let recipient_private_key = hex::decode(&identity.private_key_hex)?;
+    let content_key = tenet_crypto::crypto::unwrap_content_key(&recipient_private_key, &wrapped, b"tenet-cli")?;
+
+    let nonce = hex::decode(&envelope.payload.nonce_hex)?;
+    let ciphertext = hex::decode(&envelope.payload.ciphertext_hex)?;
+    Ok(decrypt_payload(&content_key, &nonce, &ciphertext, &aad)?)
+}
+
+fn append_json_line<T: Serialize>(path: PathBuf, value: &T) -> Result<(), Box<dyn Error>> {
+    ensure_dir(&data_dir())?;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    let json = serde_json::to_string(value)?;
+    writeln!(file, "{}", json)?;
+    Ok(())
+}
+
+fn content_id_from_bytes(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    URL_SAFE_NO_PAD.encode(digest)
+}
+
+fn build_message_id(header: &Header, payload: &EncryptedPayload) -> Result<String, Box<dyn Error>> {
+    let mut bytes = serde_json::to_vec(header)?;
+    bytes.extend_from_slice(payload.nonce_hex.as_bytes());
+    bytes.extend_from_slice(payload.ciphertext_hex.as_bytes());
+    Ok(content_id_from_bytes(&bytes))
+}
+
+fn current_timestamp() -> Result<u64, Box<dyn Error>> {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?;
+    Ok(now.as_secs())
+}


### PR DESCRIPTION
### Motivation
- Provide a tiny, usable CLI to bootstrap identities, maintain a local peer list, and exercise envelope send/receive flows through a relay for early integration and manual testing. 
- Enable end-to-end use of the existing crypto helpers (HPKE wrapping/unwrapping and AEAD payload encryption) from a simple command-line tool. 
- Make crypto errors printable and interoperable with `std::error::Error` so CLI error handling is ergonomic.

### Description
- Add a new CLI binary `src/main.rs` implementing `init`, `add-peer`, `send`, and `sync` commands that persist `identity.json`, `peers.json`, and append logs to `outbox.jsonl`/`inbox.jsonl`, build content IDs, and post/fetch envelopes from a relay via HTTP using `ureq`.
- Use existing `tenet_crypto::crypto` helpers to `generate_content_key`, `encrypt_payload`, `wrap_content_key`, and `unwrap_content_key`, and wire header AAD and message ID construction into the envelope format.
- Update `Cargo.toml` to add runtime dependencies required by the CLI (`base64`, `serde`, `serde_json`, `sha2`, `ureq`, and `hex` usage) and import `hpke::Serializable` in the CLI to access key serialization helpers.
- Implement `Display` and `std::error::Error` for `CryptoError` in `src/crypto.rs` so HPKE/AEAD errors can be propagated and shown by the CLI.

### Testing
- Ran `cargo check` for the workspace and it completed successfully (`Finished dev profile`), indicating the new CLI and changes compile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969679f87988325b323dc04f1a88f9e)