### PR TITLE
Add protocol & relay modules and tests for crypto, envelope, and relay behavior

### DIFF
--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -1,47 +1,7 @@
-use std::collections::{HashMap, VecDeque};
 use std::env;
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use axum::{
-    extract::{Path, Query, State},
-    http::StatusCode,
-    response::IntoResponse,
-    routing::{get, post},
-    Json, Router,
-};
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use sha2::{Digest, Sha256};
-
-#[derive(Clone)]
-struct RelayConfig {
-    ttl: Duration,
-    max_messages: usize,
-    max_bytes: usize,
-}
-
-#[derive(Clone)]
-struct RelayState {
-    config: RelayConfig,
-    queues: Arc<Mutex<HashMap<String, VecDeque<StoredEnvelope>>>>,
-}
-
-struct StoredEnvelope {
-    body: Value,
-    size_bytes: usize,
-    expires_at: Instant,
-}
-
-#[derive(Deserialize)]
-struct InboxQuery {
-    limit: Option<usize>,
-}
-
-#[derive(Serialize)]
-struct StoreResponse {
-    message_id: String,
-}
+use tenet_crypto::relay::{app, RelayConfig, RelayState};
 
 #[tokio::main]
 async fn main() {
@@ -51,16 +11,8 @@ async fn main() {
         max_bytes: env_usize("TENET_RELAY_MAX_BYTES", 5 * 1024 * 1024),
     };
 
-    let state = RelayState {
-        config,
-        queues: Arc::new(Mutex::new(HashMap::new())),
-    };
-
-    let app = Router::new()
-        .route("/health", get(healthcheck))
-        .route("/envelopes", post(store_envelope))
-        .route("/inbox/:recipient_id", get(fetch_inbox))
-        .with_state(state);
+    let state = RelayState::new(config);
+    let app = app(state);
 
     let bind = env::var("TENET_RELAY_BIND").unwrap_or_else(|_| "0.0.0.0:8080".to_string());
     let listener = tokio::net::TcpListener::bind(&bind)
@@ -70,109 +22,6 @@ async fn main() {
     axum::serve(listener, app)
         .await
         .unwrap_or_else(|error| panic!("server error: {error}"));
-}
-
-async fn healthcheck() -> impl IntoResponse {
-    StatusCode::OK
-}
-
-async fn store_envelope(
-    State(state): State<RelayState>,
-    Json(payload): Json<Value>,
-) -> impl IntoResponse {
-    let recipient_id = match recipient_id_from(&payload) {
-        Some(value) => value,
-        None => return (StatusCode::BAD_REQUEST, "missing recipient_id").into_response(),
-    };
-
-    let body_bytes = match serde_json::to_vec(&payload) {
-        Ok(bytes) => bytes,
-        Err(_) => return (StatusCode::BAD_REQUEST, "invalid json").into_response(),
-    };
-    let size_bytes = body_bytes.len();
-    if size_bytes > state.config.max_bytes {
-        return (StatusCode::PAYLOAD_TOO_LARGE, "payload exceeds max size").into_response();
-    }
-
-    let message_id = message_id_from(&payload, &body_bytes);
-    let stored = StoredEnvelope {
-        body: payload,
-        size_bytes,
-        expires_at: Instant::now() + state.config.ttl,
-    };
-
-    let mut queues = state
-        .queues
-        .lock()
-        .expect("relay queue lock poisoned");
-    let queue = queues.entry(recipient_id).or_insert_with(VecDeque::new);
-    prune_expired(queue);
-
-    while queue.len() >= state.config.max_messages || queue_bytes(queue) + size_bytes > state.config.max_bytes
-    {
-        queue.pop_front();
-    }
-
-    queue.push_back(stored);
-
-    (StatusCode::ACCEPTED, Json(StoreResponse { message_id })).into_response()
-}
-
-async fn fetch_inbox(
-    State(state): State<RelayState>,
-    Path(recipient_id): Path<String>,
-    Query(query): Query<InboxQuery>,
-) -> impl IntoResponse {
-    let mut queues = state
-        .queues
-        .lock()
-        .expect("relay queue lock poisoned");
-    let queue = match queues.get_mut(&recipient_id) {
-        Some(queue) => queue,
-        None => return (StatusCode::OK, Json(Vec::<Value>::new())).into_response(),
-    };
-
-    prune_expired(queue);
-    let limit = query.limit.unwrap_or(queue.len());
-    let mut envelopes = Vec::new();
-
-    for _ in 0..limit.min(queue.len()) {
-        if let Some(item) = queue.pop_front() {
-            envelopes.push(item.body);
-        }
-    }
-
-    (StatusCode::OK, Json(envelopes)).into_response()
-}
-
-fn recipient_id_from(value: &Value) -> Option<String> {
-    value
-        .pointer("/header/recipient_id")
-        .and_then(|value| value.as_str())
-        .map(str::to_string)
-}
-
-fn message_id_from(value: &Value, body_bytes: &[u8]) -> String {
-    if let Some(id) = value
-        .pointer("/message_id")
-        .and_then(|value| value.as_str())
-    {
-        return id.to_string();
-    }
-
-    let digest = Sha256::digest(body_bytes);
-    hex::encode(digest)
-}
-
-fn prune_expired(queue: &mut VecDeque<StoredEnvelope>) {
-    let now = Instant::now();
-    while matches!(queue.front(), Some(item) if item.expires_at <= now) {
-        queue.pop_front();
-    }
-}
-
-fn queue_bytes(queue: &VecDeque<StoredEnvelope>) -> usize {
-    queue.iter().map(|item| item.size_bytes).sum()
 }
 
 fn env_u64(key: &str, default_value: u64) -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod crypto;
+pub mod protocol;
+pub mod relay;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,0 +1,95 @@
+//! Tenet protocol message types (Rust).
+//!
+//! ## Spec summary
+//! - Messages are serialized with serde-compatible formats (JSON, CBOR, etc.).
+//! - Content-addressed IDs are derived from canonical serialization bytes and
+//!   encoded as URL-safe base64 without padding.
+//! - `Envelope` binds a `MessageHeader` to an encrypted `Payload`, while
+//!   `RelayPacket` wraps an opaque envelope for store-and-forward delivery.
+//! - Per-recipient key material is carried in `RecipientKey` entries, allowing
+//!   a single payload to be encrypted once and shared with many recipients.
+//!
+//! These types are intentionally small and self-contained so they can be reused
+//! across transport layers and storage backends.
+
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// A content-addressed identifier derived from serialized bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ContentId(pub String);
+
+impl ContentId {
+    /// Compute a content ID from arbitrary bytes.
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let digest = Sha256::digest(bytes);
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
+        ContentId(encoded)
+    }
+
+    /// Compute a content ID from a serde value serialized to JSON.
+    pub fn from_value<T: Serialize>(value: &T) -> Result<Self, serde_json::Error> {
+        let bytes = serde_json::to_vec(value)?;
+        Ok(Self::from_bytes(&bytes))
+    }
+}
+
+/// Per-recipient encrypted payload key material.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RecipientKey {
+    pub recipient_id: String,
+    pub key_scheme: String,
+    pub encrypted_key: String,
+}
+
+/// High-level metadata that binds a payload to a sender and recipients.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct MessageHeader {
+    pub sender_id: String,
+    pub timestamp: u64,
+    pub payload_id: ContentId,
+    pub recipients: Vec<RecipientKey>,
+    pub signature: Option<String>,
+}
+
+/// Optional references to binary attachments stored by content hash.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AttachmentRef {
+    pub content_id: ContentId,
+    pub content_type: String,
+    pub size: u64,
+}
+
+/// Encrypted user data with optional attachment references.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Payload {
+    pub id: ContentId,
+    pub content_type: String,
+    pub body: String,
+    pub attachments: Vec<AttachmentRef>,
+}
+
+/// Envelope binding a header to an encrypted payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Envelope {
+    pub id: ContentId,
+    pub header: MessageHeader,
+    pub payload: Payload,
+}
+
+/// Store-and-forward wrapper for relays or transport-specific hops.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RelayPacket {
+    pub envelope_id: ContentId,
+    pub sender_id: String,
+    pub recipient_id: String,
+    pub transport: String,
+    pub body_b64: String,
+}

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -1,0 +1,210 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+#[derive(Clone)]
+pub struct RelayConfig {
+    pub ttl: Duration,
+    pub max_messages: usize,
+    pub max_bytes: usize,
+}
+
+#[derive(Clone)]
+pub struct RelayState {
+    config: RelayConfig,
+    inner: Arc<Mutex<RelayStateInner>>,
+}
+
+struct RelayStateInner {
+    queues: HashMap<String, VecDeque<StoredEnvelope>>,
+    dedup: HashMap<String, Instant>,
+}
+
+struct StoredEnvelope {
+    body: Value,
+    size_bytes: usize,
+    expires_at: Instant,
+    message_id: String,
+}
+
+#[derive(Deserialize)]
+struct InboxQuery {
+    limit: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct StoreResponse {
+    message_id: String,
+}
+
+pub fn app(state: RelayState) -> Router {
+    Router::new()
+        .route("/health", get(healthcheck))
+        .route("/envelopes", post(store_envelope))
+        .route("/inbox/:recipient_id", get(fetch_inbox))
+        .with_state(state)
+}
+
+impl RelayState {
+    pub fn new(config: RelayConfig) -> Self {
+        Self {
+            config,
+            inner: Arc::new(Mutex::new(RelayStateInner {
+                queues: HashMap::new(),
+                dedup: HashMap::new(),
+            })),
+        }
+    }
+}
+
+async fn healthcheck() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+async fn store_envelope(
+    State(state): State<RelayState>,
+    Json(payload): Json<Value>,
+) -> impl IntoResponse {
+    let recipient_id = match recipient_id_from(&payload) {
+        Some(value) => value,
+        None => return (StatusCode::BAD_REQUEST, "missing recipient_id").into_response(),
+    };
+
+    let body_bytes = match serde_json::to_vec(&payload) {
+        Ok(bytes) => bytes,
+        Err(_) => return (StatusCode::BAD_REQUEST, "invalid json").into_response(),
+    };
+    let size_bytes = body_bytes.len();
+    if size_bytes > state.config.max_bytes {
+        return (StatusCode::PAYLOAD_TOO_LARGE, "payload exceeds max size").into_response();
+    }
+
+    let message_id = message_id_from(&payload, &body_bytes);
+    let now = Instant::now();
+    let expires_at = now + state.config.ttl;
+
+    let stored = StoredEnvelope {
+        body: payload,
+        size_bytes,
+        expires_at,
+        message_id: message_id.clone(),
+    };
+
+    let mut inner = state.inner.lock().expect("relay queue lock poisoned");
+    prune_dedup(&mut inner.dedup);
+    if inner
+        .dedup
+        .get(&message_id)
+        .is_some_and(|entry_expires| *entry_expires > now)
+    {
+        return (StatusCode::ACCEPTED, Json(StoreResponse { message_id })).into_response();
+    }
+
+    inner.dedup.insert(message_id.clone(), expires_at);
+
+    let mut evicted_ids = Vec::new();
+    {
+        let queue = inner
+            .queues
+            .entry(recipient_id)
+            .or_insert_with(VecDeque::new);
+        evicted_ids.extend(prune_expired(queue));
+
+        while queue.len() >= state.config.max_messages
+            || queue_bytes(queue) + size_bytes > state.config.max_bytes
+        {
+            if let Some(evicted) = queue.pop_front() {
+                evicted_ids.push(evicted.message_id);
+            }
+        }
+
+        queue.push_back(stored);
+    }
+
+    for message_id in evicted_ids {
+        inner.dedup.remove(&message_id);
+    }
+
+    (StatusCode::ACCEPTED, Json(StoreResponse { message_id })).into_response()
+}
+
+async fn fetch_inbox(
+    State(state): State<RelayState>,
+    Path(recipient_id): Path<String>,
+    Query(query): Query<InboxQuery>,
+) -> impl IntoResponse {
+    let mut inner = state.inner.lock().expect("relay queue lock poisoned");
+    let (expired_ids, envelopes) = match inner.queues.get_mut(&recipient_id) {
+        Some(queue) => {
+            let expired_ids = prune_expired(queue);
+            let limit = query.limit.unwrap_or(queue.len());
+            let mut envelopes = Vec::new();
+
+            for _ in 0..limit.min(queue.len()) {
+                if let Some(item) = queue.pop_front() {
+                    envelopes.push(item.body);
+                }
+            }
+
+            (expired_ids, envelopes)
+        }
+        None => return (StatusCode::OK, Json(Vec::<Value>::new())).into_response(),
+    };
+
+    for message_id in expired_ids {
+        inner.dedup.remove(&message_id);
+    }
+    prune_dedup(&mut inner.dedup);
+
+    (StatusCode::OK, Json(envelopes)).into_response()
+}
+
+fn recipient_id_from(value: &Value) -> Option<String> {
+    value
+        .pointer("/header/recipient_id")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+fn message_id_from(value: &Value, body_bytes: &[u8]) -> String {
+    if let Some(id) = value
+        .pointer("/message_id")
+        .and_then(|value| value.as_str())
+    {
+        return id.to_string();
+    }
+
+    let digest = Sha256::digest(body_bytes);
+    hex::encode(digest)
+}
+
+fn prune_expired(queue: &mut VecDeque<StoredEnvelope>) -> Vec<String> {
+    let now = Instant::now();
+    let mut expired_ids = Vec::new();
+    while matches!(queue.front(), Some(item) if item.expires_at <= now) {
+        if let Some(expired) = queue.pop_front() {
+            expired_ids.push(expired.message_id);
+        }
+    }
+    expired_ids
+}
+
+fn prune_dedup(dedup: &mut HashMap<String, Instant>) {
+    let now = Instant::now();
+    dedup.retain(|_, expires_at| *expires_at > now);
+}
+
+fn queue_bytes(queue: &VecDeque<StoredEnvelope>) -> usize {
+    queue.iter().map(|item| item.size_bytes).sum()
+}

--- a/tests/crypto_tests.rs
+++ b/tests/crypto_tests.rs
@@ -1,0 +1,45 @@
+use hpke::kem::X25519HkdfSha256;
+use hpke::Kem as _;
+use hpke::Serializable;
+use rand_chacha::ChaCha20Rng;
+use rand::SeedableRng;
+
+use tenet_crypto::crypto::{decrypt_payload, encrypt_payload, wrap_content_key, unwrap_content_key};
+
+#[test]
+fn aead_encrypts_and_decrypts_payload() {
+    let content_key = [7u8; 32];
+    let plaintext = b"tenet test payload";
+    let aad = b"tenet-header";
+
+    let (nonce, ciphertext) =
+        encrypt_payload(&content_key, plaintext, aad, None).expect("encrypt payload");
+    let decrypted =
+        decrypt_payload(&content_key, &nonce, &ciphertext, aad).expect("decrypt payload");
+
+    assert_eq!(decrypted, plaintext);
+}
+
+#[test]
+fn hpke_wraps_and_unwraps_content_key() {
+    let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+    let (recipient_private, recipient_public) = X25519HkdfSha256::gen_keypair(&mut rng);
+    let content_key = [3u8; 32];
+
+    let wrapped = wrap_content_key(
+        &recipient_public.to_bytes(),
+        &content_key,
+        b"tenet-hpke-test",
+        Some([1u8; 32]),
+    )
+    .expect("wrap content key");
+
+    let unwrapped = unwrap_content_key(
+        &recipient_private.to_bytes(),
+        &wrapped,
+        b"tenet-hpke-test",
+    )
+    .expect("unwrap content key");
+
+    assert_eq!(unwrapped, content_key);
+}

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -1,0 +1,40 @@
+use tenet_crypto::protocol::{
+    AttachmentRef, ContentId, Envelope, MessageHeader, Payload, RecipientKey,
+};
+
+#[test]
+fn envelope_roundtrips_via_json() {
+    let payload = Payload {
+        id: ContentId::from_bytes(b"payload-body"),
+        content_type: "application/octet-stream".to_string(),
+        body: "deadbeef".to_string(),
+        attachments: vec![AttachmentRef {
+            content_id: ContentId::from_bytes(b"attachment-1"),
+            content_type: "image/png".to_string(),
+            size: 128,
+        }],
+    };
+
+    let header = MessageHeader {
+        sender_id: "sender-id".to_string(),
+        timestamp: 1_700_000_000,
+        payload_id: payload.id.clone(),
+        recipients: vec![RecipientKey {
+            recipient_id: "recipient-id".to_string(),
+            key_scheme: "hpke-x25519".to_string(),
+            encrypted_key: "base64-key".to_string(),
+        }],
+        signature: Some("sig".to_string()),
+    };
+
+    let envelope = Envelope {
+        id: ContentId::from_value(&header).expect("content id"),
+        header,
+        payload,
+    };
+
+    let json = serde_json::to_string(&envelope).expect("serialize envelope");
+    let decoded: Envelope = serde_json::from_str(&json).expect("deserialize envelope");
+
+    assert_eq!(decoded, envelope);
+}

--- a/tests/relay_tests.rs
+++ b/tests/relay_tests.rs
@@ -1,0 +1,272 @@
+use std::time::Duration;
+
+use axum::Router;
+use base64::Engine as _;
+use hpke::kem::X25519HkdfSha256;
+use hpke::Kem as _;
+use hpke::Serializable;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::sync::oneshot;
+
+use tenet_crypto::crypto::{decrypt_payload, encrypt_payload, wrap_content_key, unwrap_content_key};
+use tenet_crypto::relay::{app, RelayConfig, RelayState};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Header {
+    sender_id: String,
+    recipient_id: String,
+    timestamp: u64,
+    content_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WrappedKeyData {
+    enc_hex: String,
+    ciphertext_hex: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EncryptedPayload {
+    nonce_hex: String,
+    ciphertext_hex: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Envelope {
+    message_id: String,
+    header: Header,
+    wrapped_key: WrappedKeyData,
+    payload: EncryptedPayload,
+}
+
+async fn start_relay(config: RelayConfig) -> (String, oneshot::Sender<()>) {
+    let state = RelayState::new(config);
+    let app: Router = app(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind relay");
+    let addr = listener.local_addr().expect("relay addr");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+    let server = axum::serve(listener, app).with_graceful_shutdown(async {
+        let _ = shutdown_rx.await;
+    });
+    tokio::spawn(async move {
+        let _ = server.await;
+    });
+
+    (format!("http://{}", addr), shutdown_tx)
+}
+
+fn build_message_id(header: &Header, payload: &EncryptedPayload) -> String {
+    let mut bytes = serde_json::to_vec(header).expect("header bytes");
+    bytes.extend_from_slice(payload.nonce_hex.as_bytes());
+    bytes.extend_from_slice(payload.ciphertext_hex.as_bytes());
+    let digest = Sha256::digest(bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
+}
+
+fn post_envelope(base_url: &str, envelope: &Envelope) {
+    let body = serde_json::to_string(envelope).expect("serialize envelope");
+    let response = ureq::post(&format!("{}/envelopes", base_url))
+        .set("Content-Type", "application/json")
+        .send_string(&body)
+        .expect("post envelope");
+    assert!(response.status() < 400, "relay rejected envelope");
+}
+
+fn fetch_inbox(base_url: &str, recipient_id: &str) -> Vec<Envelope> {
+    let response = ureq::get(&format!("{}/inbox/{}", base_url, recipient_id))
+        .call()
+        .expect("fetch inbox");
+    let body = response.into_string().expect("inbox body");
+    serde_json::from_str(&body).expect("deserialize inbox")
+}
+
+#[tokio::test]
+async fn relay_expires_messages_after_ttl() {
+    let (base_url, shutdown_tx) = start_relay(RelayConfig {
+        ttl: Duration::from_millis(50),
+        max_messages: 10,
+        max_bytes: 1024 * 1024,
+    })
+    .await;
+
+    let envelope = Envelope {
+        message_id: "expire-test".to_string(),
+        header: Header {
+            sender_id: "sender".to_string(),
+            recipient_id: "recipient".to_string(),
+            timestamp: 1,
+            content_type: "text/plain".to_string(),
+        },
+        wrapped_key: WrappedKeyData {
+            enc_hex: "00".to_string(),
+            ciphertext_hex: "11".to_string(),
+        },
+        payload: EncryptedPayload {
+            nonce_hex: "22".to_string(),
+            ciphertext_hex: "33".to_string(),
+        },
+    };
+
+    tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        let envelope = envelope.clone();
+        move || post_envelope(&base_url, &envelope)
+    })
+    .await
+    .expect("post task");
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let inbox = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        move || fetch_inbox(&base_url, "recipient")
+    })
+    .await
+    .expect("fetch task");
+
+    shutdown_tx.send(()).ok();
+
+    assert!(inbox.is_empty(), "expected expired inbox");
+}
+
+#[tokio::test]
+async fn relay_deduplicates_by_message_id() {
+    let (base_url, shutdown_tx) = start_relay(RelayConfig {
+        ttl: Duration::from_secs(5),
+        max_messages: 10,
+        max_bytes: 1024 * 1024,
+    })
+    .await;
+
+    let envelope = Envelope {
+        message_id: "dedupe-test".to_string(),
+        header: Header {
+            sender_id: "sender".to_string(),
+            recipient_id: "recipient".to_string(),
+            timestamp: 1,
+            content_type: "text/plain".to_string(),
+        },
+        wrapped_key: WrappedKeyData {
+            enc_hex: "aa".to_string(),
+            ciphertext_hex: "bb".to_string(),
+        },
+        payload: EncryptedPayload {
+            nonce_hex: "cc".to_string(),
+            ciphertext_hex: "dd".to_string(),
+        },
+    };
+
+    tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        let envelope = envelope.clone();
+        move || {
+            post_envelope(&base_url, &envelope);
+            post_envelope(&base_url, &envelope);
+        }
+    })
+    .await
+    .expect("post task");
+
+    let inbox = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        move || fetch_inbox(&base_url, "recipient")
+    })
+    .await
+    .expect("fetch task");
+
+    shutdown_tx.send(()).ok();
+
+    assert_eq!(inbox.len(), 1);
+}
+
+#[tokio::test]
+async fn node_can_send_and_receive_through_relay() {
+    let (base_url, shutdown_tx) = start_relay(RelayConfig {
+        ttl: Duration::from_secs(5),
+        max_messages: 10,
+        max_bytes: 1024 * 1024,
+    })
+    .await;
+
+    let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
+    let (recipient_private, recipient_public) = X25519HkdfSha256::gen_keypair(&mut rng);
+    let recipient_id = "recipient-node";
+
+    let header = Header {
+        sender_id: "sender-node".to_string(),
+        recipient_id: recipient_id.to_string(),
+        timestamp: 123,
+        content_type: "text/plain".to_string(),
+    };
+    let aad = serde_json::to_vec(&header).expect("aad");
+    let content_key = [11u8; 32];
+    let plaintext = b"hello relay";
+
+    let (nonce, ciphertext) =
+        encrypt_payload(&content_key, plaintext, &aad, None).expect("encrypt payload");
+    let wrapped = wrap_content_key(
+        &recipient_public.to_bytes(),
+        &content_key,
+        b"tenet-cli",
+        Some([2u8; 32]),
+    )
+    .expect("wrap content key");
+
+    let payload = EncryptedPayload {
+        nonce_hex: hex::encode(nonce),
+        ciphertext_hex: hex::encode(ciphertext),
+    };
+    let message_id = build_message_id(&header, &payload);
+    let envelope = Envelope {
+        message_id,
+        header,
+        wrapped_key: WrappedKeyData {
+            enc_hex: hex::encode(wrapped.enc),
+            ciphertext_hex: hex::encode(wrapped.ciphertext),
+        },
+        payload,
+    };
+
+    tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        let envelope = envelope.clone();
+        move || post_envelope(&base_url, &envelope)
+    })
+    .await
+    .expect("post task");
+
+    let inbox = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        move || fetch_inbox(&base_url, recipient_id)
+    })
+    .await
+    .expect("fetch task");
+
+    shutdown_tx.send(()).ok();
+
+    let fetched = inbox.first().expect("fetched envelope");
+    let wrapped = tenet_crypto::crypto::WrappedKey {
+        enc: hex::decode(&fetched.wrapped_key.enc_hex).expect("enc bytes"),
+        ciphertext: hex::decode(&fetched.wrapped_key.ciphertext_hex).expect("cipher bytes"),
+    };
+    let content_key = unwrap_content_key(
+        &recipient_private.to_bytes(),
+        &wrapped,
+        b"tenet-cli",
+    )
+    .expect("unwrap content key");
+    let nonce = hex::decode(&fetched.payload.nonce_hex).expect("nonce bytes");
+    let ciphertext = hex::decode(&fetched.payload.ciphertext_hex).expect("cipher bytes");
+
+    let aad = serde_json::to_vec(&fetched.header).expect("aad");
+    let decrypted =
+        decrypt_payload(&content_key, &nonce, &ciphertext, &aad).expect("decrypt payload");
+
+    assert_eq!(decrypted, plaintext);
+}


### PR DESCRIPTION
### Motivation
- Provide first-class protocol types and a shared relay implementation to centralize message formats and relay behavior.
- Increase test coverage for core crypto primitives and relay semantics (TTL, deduplication, and end-to-end delivery).

### Description
- Add `src/protocol.rs` defining `ContentId`, `RecipientKey`, `MessageHeader`, `AttachmentRef`, `Payload`, `Envelope`, and `RelayPacket` with JSON (serde) serialization helpers.
- Add `src/relay.rs` implementing a shared relay module with `RelayConfig` and `RelayState` that enforces TTL, size/message caps, per-recipient queues, and a deduplication index that is pruned alongside eviction.
- Refactor the relay binary in `src/bin/relay.rs` to use the new `RelayState` and exported `app()` router instead of duplicating relay logic.
- Add tests: `tests/crypto_tests.rs` covering AEAD encrypt/decrypt and HPKE wrap/unwrap, `tests/protocol_tests.rs` covering envelope JSON serialization/deserialization, and `tests/relay_tests.rs` covering relay TTL expiry, deduplication, and an in-process node+relay integration flow that posts/fetches envelopes and verifies decryption.
- Small test and implementation fixes (dedup eviction logic and test imports such as `hpke::Serializable`) to make the new tests compile and run.

### Testing
- Ran the full test suite with `cargo test`, which executed library unit tests and the new test files and completed successfully; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697c433bb48325a8e09962d832b9c1)