### PR TITLE
Add versioned Envelope/Header with canonical signing bytes and validation

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,7 +4,7 @@
 //! - Messages are serialized with serde-compatible formats (JSON, CBOR, etc.).
 //! - Content-addressed IDs are derived from canonical serialization bytes and
 //!   encoded as URL-safe base64 without padding.
-//! - `Envelope` binds a `MessageHeader` to an encrypted `Payload`, while
+//! - `Envelope` binds a `Header` to an encrypted `Payload`, while
 //!   `RelayPacket` wraps an opaque envelope for store-and-forward delivery.
 //! - Per-recipient key material is carried in `RecipientKey` entries, allowing
 //!   a single payload to be encrypted once and shared with many recipients.
@@ -44,15 +44,102 @@ pub struct RecipientKey {
     pub encrypted_key: String,
 }
 
-/// High-level metadata that binds a payload to a sender and recipients.
+/// Supported protocol versions for envelopes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtocolVersion {
+    V1,
+}
+
+impl ProtocolVersion {
+    pub fn is_supported(self) -> bool {
+        matches!(self, ProtocolVersion::V1)
+    }
+}
+
+/// High-level metadata that binds a payload to a sender and recipient.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub struct MessageHeader {
+pub struct Header {
     pub sender_id: String,
+    pub recipient_id: String,
     pub timestamp: u64,
-    pub payload_id: ContentId,
-    pub recipients: Vec<RecipientKey>,
+    pub message_id: ContentId,
+    pub ttl_seconds: u64,
+    pub payload_size: u64,
     pub signature: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+struct CanonicalHeader<'a> {
+    version: ProtocolVersion,
+    sender_id: &'a str,
+    recipient_id: &'a str,
+    timestamp: u64,
+    message_id: &'a ContentId,
+    ttl_seconds: u64,
+    payload_size: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeaderError {
+    MissingSignature,
+    InvalidSignature,
+    UnsupportedVersion(ProtocolVersion),
+    TtlOutOfRange { ttl_seconds: u64 },
+}
+
+impl Header {
+    pub const MAX_TTL_SECONDS: u64 = 7 * 24 * 60 * 60;
+
+    /// Canonical bytes for signing (JSON, deterministic field order).
+    pub fn canonical_signing_bytes(
+        &self,
+        version: ProtocolVersion,
+    ) -> Result<Vec<u8>, serde_json::Error> {
+        let canonical = CanonicalHeader {
+            version,
+            sender_id: &self.sender_id,
+            recipient_id: &self.recipient_id,
+            timestamp: self.timestamp,
+            message_id: &self.message_id,
+            ttl_seconds: self.ttl_seconds,
+            payload_size: self.payload_size,
+        };
+        serde_json::to_vec(&canonical)
+    }
+
+    /// Compute the expected signature for this header and version.
+    pub fn expected_signature(
+        &self,
+        version: ProtocolVersion,
+    ) -> Result<String, serde_json::Error> {
+        let bytes = self.canonical_signing_bytes(version)?;
+        let digest = Sha256::digest(&bytes);
+        Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest))
+    }
+
+    /// Verify signature validity, version compatibility, and TTL bounds.
+    pub fn verify_signature(&self, version: ProtocolVersion) -> Result<(), HeaderError> {
+        if !version.is_supported() {
+            return Err(HeaderError::UnsupportedVersion(version));
+        }
+        if self.ttl_seconds == 0 || self.ttl_seconds > Self::MAX_TTL_SECONDS {
+            return Err(HeaderError::TtlOutOfRange {
+                ttl_seconds: self.ttl_seconds,
+            });
+        }
+        let signature = self.signature.as_deref().ok_or(HeaderError::MissingSignature)?;
+        let expected = self
+            .expected_signature(version)
+            .map_err(|_| HeaderError::InvalidSignature)?;
+        if signature == expected {
+            Ok(())
+        } else {
+            Err(HeaderError::InvalidSignature)
+        }
+    }
 }
 
 /// Optional references to binary attachments stored by content hash.
@@ -78,8 +165,8 @@ pub struct Payload {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Envelope {
-    pub id: ContentId,
-    pub header: MessageHeader,
+    pub version: ProtocolVersion,
+    pub header: Header,
     pub payload: Payload,
 }
 


### PR DESCRIPTION
### Motivation
- Introduce a versioned, explicit header/envelope representation to make sender/recipient, timing, message, TTL and payload size explicit and amenable to signing and validation.
- Define a canonical byte representation for header signing and provide helpers to validate signatures, version compatibility, and TTL bounds.

### Description
- Add `ProtocolVersion` enum and make `Envelope` include a `version` and a new `Header` type with fields `sender_id`, `recipient_id`, `timestamp`, `message_id`, `ttl_seconds`, `payload_size`, and `signature`.
- Implement a `CanonicalHeader` representation and `Header::canonical_signing_bytes` to produce deterministic JSON bytes used for signing, and `Header::expected_signature` to compute a SHA-256+base64 signature value.
- Add `Header::verify_signature` with checks for supported version, TTL bounds, and signature equality, and introduce `HeaderError` for failure cases.
- Update `tests/protocol_tests.rs` to exercise JSON round-trip serialization and an invalid-signature failure case, and update serde derives where appropriate.

### Testing
- Ran the full test suite with `cargo test` and all tests completed successfully.
- The new tests in `tests/protocol_tests.rs` (`envelope_roundtrips_via_json` and `header_signature_fails_with_invalid_signature`) passed as part of the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969a40df7b483258301091b648bf501)