### PR TITLE
Add message-size distribution and lorem-based message generator for simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +728,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +782,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -908,6 +930,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -1164,6 +1196,7 @@ dependencies = [
  "hpke",
  "rand",
  "rand_chacha",
+ "rand_distr",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ hex = "0.4"
 hpke = "0.11"
 rand = "0.8"
 rand_chacha = "0.3"
+rand_distr = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use tenet_crypto::relay::RelayConfig;
 use tenet_crypto::simulation::{
-    build_simulation_inputs, FriendsPerNode, OnlineAvailability, PlannedSend, PostFrequency,
-    SimMessage, SimulationConfig, SimulationHarness, start_relay,
+    build_simulation_inputs, FriendsPerNode, MessageSizeDistribution, OnlineAvailability,
+    PlannedSend, PostFrequency, SimMessage, SimulationConfig, SimulationHarness, start_relay,
 };
 
 #[tokio::test]
@@ -30,6 +30,7 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
             total_posts: 3,
         },
         availability: OnlineAvailability::Bernoulli { p_online: 1.0 },
+        message_size_distribution: MessageSizeDistribution::Uniform { min: 8, max: 32 },
         seed: 42,
     };
 


### PR DESCRIPTION
### Motivation
- Enable simulation of realistic message payload sizes by adding a configurable size distribution and generating message bodies that reflect that distribution.
- Wire the generated bodies into planned sends so `SimMessage` instances contain payloads sized according to the distribution.

### Description
- Add `MessageSizeDistribution` enum (variants `Uniform`, `Normal`, `LogNormal`) and include it in `SimulationConfig` as `message_size_distribution`.
- Implement `sample_message_size` and `generate_message_body` which sample sizes (using `rand_distr` for normal/log-normal) and produce a deterministic lorem-ipsum string truncated to the sampled size.
- Integrate the generator into `build_planned_sends` so planned `SimMessage.body` values are produced from the configured distribution and add normalization/clamping and safe defaults for invalid parameters.
- Add the `rand_distr` dependency and update the simulation test configuration to include a `message_size_distribution` entry.

### Testing
- Ran `cargo check`; the build fails due to unrelated issues in `src/bin/toy_ui.rs` (missing `ureq` JSON helper methods `send_json`/`into_json` and a borrow-check error), so type-checking the whole workspace did not succeed.
- No simulation-specific unit tests were executed in this run, but the existing simulation harness test was updated to set a `MessageSizeDistribution` configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f7ca5ae88325b31f866629251304)