### PR TITLE
Add simulation scenarios & clustering, relay peer/message logging, readline toy debugger, and crate/binary renames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +236,15 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -409,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +443,23 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -592,6 +630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -856,6 +903,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +987,27 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1084,6 +1158,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1260,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1312,28 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ryu"
@@ -1471,7 +1590,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "tenet-crypto"
+name = "tenet"
 version = "0.1.0"
 dependencies = [
  "axum",
@@ -1484,6 +1603,7 @@ dependencies = [
  "rand_chacha",
  "rand_distr",
  "ratatui",
+ "rustyline",
  "serde",
  "serde_json",
  "sha2",
@@ -1702,6 +1822,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,26 @@
 [package]
-name = "tenet-crypto"
+name = "tenet"
 version = "0.1.0"
 edition = "2021"
+
+[lib]
+name = "tenet"
+
+[[bin]]
+name = "tenet"
+path = "src/bin/tenet-crypto.rs"
+
+[[bin]]
+name = "tenet-sim"
+path = "src/bin/simulation.rs"
+
+[[bin]]
+name = "tenet-debugger"
+path = "src/bin/toy_ui.rs"
+
+[[bin]]
+name = "tenet-relay"
+path = "src/bin/relay.rs"
 
 [dependencies]
 base64 = "0.22"
@@ -14,6 +33,7 @@ rand = "0.8"
 rand_chacha = "0.3"
 rand_distr = "0.4"
 ratatui = "0.26"
+rustyline = "14.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ cargo build
 Run the CLI:
 
 ```bash
-cargo run --bin tenet-crypto -- init
-cargo run --bin tenet-crypto -- add-peer <name> <public_key_hex>
+cargo run --bin tenet -- init
+cargo run --bin tenet -- add-peer <name> <public_key_hex>
 ```
 
 Run the relay service (defaults to `0.0.0.0:8080`):
 
 ```bash
-cargo run --bin relay
+cargo run --bin tenet-relay
 ```
 
 You can also configure the relay via environment variables:
@@ -40,13 +40,15 @@ TENET_RELAY_BIND=127.0.0.1:8080 \
 TENET_RELAY_TTL_SECS=3600 \
 TENET_RELAY_MAX_MESSAGES=1000 \
 TENET_RELAY_MAX_BYTES=5242880 \
-  cargo run --bin relay
+TENET_RELAY_PEER_LOG_WINDOW_SECS=60 \
+TENET_RELAY_PEER_LOG_INTERVAL_SECS=30 \
+  cargo run --bin tenet-relay
 ```
 
 Run the toy UI (spawns N peers, defaults to 3):
 
 ```bash
-cargo run --bin toy_ui -- --peers 4 --relay http://127.0.0.1:8080
+cargo run --bin tenet-debugger -- --peers 4 --relay http://127.0.0.1:8080
 ```
 
 Once running, try:
@@ -68,7 +70,14 @@ cargo test
 
 ## Simulation
 
-The simulation harness is implemented as an integration test. Run it directly with:
+Scenario-driven simulation runs are documented in [docs/simulation.md](docs/simulation.md) and
+sample scenarios live in `scenarios/`. Run one with:
+
+```bash
+cargo run --bin tenet-sim -- scenarios/small_dense_6.toml
+```
+
+The simulation harness is also implemented as an integration test. Run it directly with:
 
 ```bash
 cargo test --test simulation_harness_tests

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -1,0 +1,141 @@
+Simulation scenarios
+====================
+
+Simulation scenarios are TOML files consumed by `tenet-sim`. Each scenario has a `[simulation]`
+section that describes the network behavior and a `[relay]` section that configures the in-process
+relay used during the run. You can find ready-made scenarios in `scenarios/`.
+
+## Top-level layout
+
+```toml
+[simulation]
+# ... required simulation fields ...
+
+[relay]
+# ... relay settings ...
+
+# direct_enabled = true
+```
+
+`direct_enabled` is optional. When omitted the simulation uses direct delivery links in addition to
+the relay.
+
+## `[simulation]` fields
+
+- `node_ids` (array of strings): IDs to use for simulated peers.
+- `steps` (integer): number of simulation steps.
+- `seed` (integer): RNG seed.
+- `friends_per_node`: friend graph distribution (see below).
+- `post_frequency`: how often each node posts (see below).
+- `availability`: online/offline behavior (see below).
+- `message_size_distribution`: message size generator (see below).
+- `clustering` (optional): cluster layout for dense subgraphs with sparse cross-links.
+
+### `friends_per_node`
+
+```toml
+[simulation.friends_per_node]
+type = "uniform"
+min = 2
+max = 6
+```
+
+```toml
+[simulation.friends_per_node]
+type = "poisson"
+lambda = 3.5
+```
+
+```toml
+[simulation.friends_per_node]
+type = "zipf"
+max = 12
+exponent = 1.2
+```
+
+### `post_frequency`
+
+```toml
+[simulation.post_frequency]
+type = "poisson"
+lambda_per_step = 0.4
+```
+
+```toml
+[simulation.post_frequency]
+type = "weighted_schedule"
+weights = [1, 1, 2, 3, 5]
+# total posts per node
+total_posts = 20
+```
+
+### `availability`
+
+```toml
+[simulation.availability]
+type = "bernoulli"
+p_online = 0.75
+```
+
+```toml
+[simulation.availability]
+type = "markov"
+p_online_given_online = 0.92
+p_online_given_offline = 0.25
+start_online_prob = 0.8
+```
+
+### `message_size_distribution`
+
+```toml
+[simulation.message_size_distribution]
+type = "uniform"
+min = 20
+max = 300
+```
+
+```toml
+[simulation.message_size_distribution]
+type = "normal"
+mean = 120
+std_dev = 30
+min = 40
+max = 400
+```
+
+```toml
+[simulation.message_size_distribution]
+type = "log_normal"
+mean = 3.2
+std_dev = 0.7
+min = 40
+max = 400
+```
+
+### `clustering` (optional)
+
+```toml
+[simulation.clustering]
+cluster_sizes = [8, 8, 8, 12]
+inter_cluster_friend_probability = 0.02
+```
+
+Clusters are assigned in order from `node_ids`. The `cluster_sizes` list is consumed in order,
+with any remaining nodes appended as a final cluster. `friends_per_node` is sampled within each
+cluster. `inter_cluster_friend_probability` controls the chance of creating a cross-cluster
+connection for each node pair from different clusters.
+
+## `[relay]` fields
+
+```toml
+[relay]
+ttl_seconds = 3600
+max_messages = 1000
+max_bytes = 5242880
+retry_backoff_seconds = [1, 2, 4]
+peer_log_window_seconds = 60
+peer_log_interval_seconds = 30
+```
+
+The relay logging fields are optional; when omitted they default to a 60-second window with a
+30-second summary interval.

--- a/scenarios/large_clustered_100.toml
+++ b/scenarios/large_clustered_100.toml
@@ -1,0 +1,40 @@
+[simulation]
+node_ids = ["node-1", "node-2", "node-3", "node-4", "node-5", "node-6", "node-7", "node-8", "node-9", "node-10", "node-11", "node-12", "node-13", "node-14", "node-15", "node-16", "node-17", "node-18", "node-19", "node-20", "node-21", "node-22", "node-23", "node-24", "node-25", "node-26", "node-27", "node-28", "node-29", "node-30", "node-31", "node-32", "node-33", "node-34", "node-35", "node-36", "node-37", "node-38", "node-39", "node-40", "node-41", "node-42", "node-43", "node-44", "node-45", "node-46", "node-47", "node-48", "node-49", "node-50", "node-51", "node-52", "node-53", "node-54", "node-55", "node-56", "node-57", "node-58", "node-59", "node-60", "node-61", "node-62", "node-63", "node-64", "node-65", "node-66", "node-67", "node-68", "node-69", "node-70", "node-71", "node-72", "node-73", "node-74", "node-75", "node-76", "node-77", "node-78", "node-79", "node-80", "node-81", "node-82", "node-83", "node-84", "node-85", "node-86", "node-87", "node-88", "node-89", "node-90", "node-91", "node-92", "node-93", "node-94", "node-95", "node-96", "node-97", "node-98", "node-99", "node-100"]
+steps = 200
+seed = 1337
+
+[simulation.friends_per_node]
+type = "uniform"
+min = 2
+max = 5
+
+[simulation.clustering]
+cluster_sizes = [8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 12]
+inter_cluster_friend_probability = 0.015
+
+[simulation.post_frequency]
+type = "poisson"
+lambda_per_step = 0.35
+
+[simulation.availability]
+type = "markov"
+p_online_given_online = 0.92
+p_online_given_offline = 0.25
+start_online_prob = 0.8
+
+[simulation.message_size_distribution]
+type = "log_normal"
+mean = 3.5
+std_dev = 0.6
+min = 40
+max = 400
+
+[relay]
+ttl_seconds = 3600
+max_messages = 2000
+max_bytes = 5242880
+retry_backoff_seconds = [1, 2, 5]
+peer_log_window_seconds = 60
+peer_log_interval_seconds = 20
+
+# direct_enabled = true

--- a/scenarios/small_dense_6.toml
+++ b/scenarios/small_dense_6.toml
@@ -1,0 +1,32 @@
+[simulation]
+node_ids = ["node-1", "node-2", "node-3", "node-4", "node-5", "node-6"]
+steps = 60
+seed = 42
+
+[simulation.friends_per_node]
+type = "uniform"
+min = 4
+max = 5
+
+[simulation.post_frequency]
+type = "poisson"
+lambda_per_step = 0.6
+
+[simulation.availability]
+type = "bernoulli"
+p_online = 0.9
+
+[simulation.message_size_distribution]
+type = "uniform"
+min = 20
+max = 120
+
+[relay]
+ttl_seconds = 3600
+max_messages = 500
+max_bytes = 1048576
+retry_backoff_seconds = [1, 2, 4]
+peer_log_window_seconds = 30
+peer_log_interval_seconds = 10
+
+# direct_enabled = true

--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::time::Duration;
 
-use tenet_crypto::relay::{app, RelayConfig, RelayState};
+use tenet::relay::{app, RelayConfig, RelayState};
 
 #[tokio::main]
 async fn main() {
@@ -16,9 +16,12 @@ async fn main() {
                 Duration::from_millis(100),
             ]
         }),
+        peer_log_window: Duration::from_secs(env_u64("TENET_RELAY_PEER_LOG_WINDOW_SECS", 60)),
+        peer_log_interval: Duration::from_secs(env_u64("TENET_RELAY_PEER_LOG_INTERVAL_SECS", 30)),
     };
 
     let state = RelayState::new(config);
+    state.start_peer_log_task();
     let app = app(state);
 
     let bind = env::var("TENET_RELAY_BIND").unwrap_or_else(|_| "0.0.0.0:8080".to_string());

--- a/src/bin/simulation.rs
+++ b/src/bin/simulation.rs
@@ -14,7 +14,7 @@ use ratatui::widgets::{Block, Borders, Gauge, Paragraph};
 use ratatui::Terminal;
 use tokio::sync::mpsc;
 
-use tenet_crypto::simulation::{
+use tenet::simulation::{
     run_simulation_scenario, run_simulation_scenario_with_progress, RollingLatencySnapshot,
     SimulationScenarioConfig, SimulationStepUpdate,
 };
@@ -30,11 +30,11 @@ async fn main() -> Result<(), String> {
         } else if path.is_none() {
             path = Some(arg);
         } else {
-            return Err("usage: simulation [--tui] <path-to-scenario.toml>".to_string());
+            return Err("usage: tenet-sim [--tui] <path-to-scenario.toml>".to_string());
         }
     }
     let path =
-        path.ok_or_else(|| "usage: simulation [--tui] <path-to-scenario.toml>".to_string())?;
+        path.ok_or_else(|| "usage: tenet-sim [--tui] <path-to-scenario.toml>".to_string())?;
     let contents = fs::read_to_string(&path).map_err(|err| err.to_string())?;
     let scenario: SimulationScenarioConfig =
         toml::from_str(&contents).map_err(|err| err.to_string())?;
@@ -51,7 +51,7 @@ async fn main() -> Result<(), String> {
 
 async fn run_with_tui(
     scenario: SimulationScenarioConfig,
-) -> Result<tenet_crypto::simulation::SimulationReport, String> {
+) -> Result<tenet::simulation::SimulationReport, String> {
     enable_raw_mode().map_err(|err| err.to_string())?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen).map_err(|err| err.to_string())?;

--- a/src/bin/tenet-crypto.rs
+++ b/src/bin/tenet-crypto.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-use tenet_crypto::crypto::{
+use tenet::crypto::{
     decrypt_payload, derive_user_id_from_public_key, encrypt_payload, generate_content_key,
     generate_keypair, load_keypair, rotate_keypair, store_keypair, wrap_content_key,
     KeyRotation, StoredKeypair, WrappedKey,
@@ -89,7 +89,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 fn print_usage() {
     println!(
-        "tenet-crypto commands:\n\
+        "tenet commands:\n\
          \n\
          init\n\
          add-peer <name> <public_key_hex>\n\
@@ -405,7 +405,7 @@ fn decrypt_envelope(identity: &StoredKeypair, envelope: &Envelope) -> Result<Vec
 
     let recipient_private_key = hex::decode(&identity.private_key_hex)?;
     let content_key =
-        tenet_crypto::crypto::unwrap_content_key(&recipient_private_key, &wrapped, b"tenet-cli")?;
+        tenet::crypto::unwrap_content_key(&recipient_private_key, &wrapped, b"tenet-cli")?;
 
     let nonce = hex::decode(&envelope.payload.nonce_hex)?;
     let ciphertext = hex::decode(&envelope.payload.ciphertext_hex)?;

--- a/tests/crypto_tests.rs
+++ b/tests/crypto_tests.rs
@@ -4,7 +4,7 @@ use hpke::Serializable;
 use rand_chacha::ChaCha20Rng;
 use rand::SeedableRng;
 
-use tenet_crypto::crypto::{decrypt_payload, encrypt_payload, wrap_content_key, unwrap_content_key};
+use tenet::crypto::{decrypt_payload, encrypt_payload, wrap_content_key, unwrap_content_key};
 
 #[test]
 fn aead_encrypts_and_decrypts_payload() {

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -1,4 +1,4 @@
-use tenet_crypto::protocol::{
+use tenet::protocol::{
     AttachmentRef, ContentId, Envelope, Header, HeaderError, Payload, ProtocolVersion,
 };
 

--- a/tests/relay_tests.rs
+++ b/tests/relay_tests.rs
@@ -11,10 +11,10 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::sync::oneshot;
 
-use tenet_crypto::crypto::{
+use tenet::crypto::{
     decrypt_payload, encrypt_payload, unwrap_content_key, wrap_content_key,
 };
-use tenet_crypto::relay::{app, RelayConfig, RelayState};
+use tenet::relay::{app, RelayConfig, RelayState};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct Header {
@@ -95,6 +95,8 @@ async fn relay_expires_messages_after_ttl() {
         max_messages: 10,
         max_bytes: 1024 * 1024,
         retry_backoff: Vec::new(),
+        peer_log_window: Duration::from_secs(60),
+        peer_log_interval: Duration::from_secs(30),
     })
     .await;
 
@@ -145,6 +147,8 @@ async fn relay_deduplicates_by_message_id() {
         max_messages: 10,
         max_bytes: 1024 * 1024,
         retry_backoff: Vec::new(),
+        peer_log_window: Duration::from_secs(60),
+        peer_log_interval: Duration::from_secs(30),
     })
     .await;
 
@@ -196,6 +200,8 @@ async fn node_can_send_and_receive_through_relay() {
         max_messages: 10,
         max_bytes: 1024 * 1024,
         retry_backoff: Vec::new(),
+        peer_log_window: Duration::from_secs(60),
+        peer_log_interval: Duration::from_secs(30),
     })
     .await;
 
@@ -256,7 +262,7 @@ async fn node_can_send_and_receive_through_relay() {
     shutdown_tx.send(()).ok();
 
     let fetched = inbox.first().expect("fetched envelope");
-    let wrapped = tenet_crypto::crypto::WrappedKey {
+    let wrapped = tenet::crypto::WrappedKey {
         enc: hex::decode(&fetched.wrapped_key.enc_hex).expect("enc bytes"),
         ciphertext: hex::decode(&fetched.wrapped_key.ciphertext_hex).expect("cipher bytes"),
     };

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
-use tenet_crypto::relay::RelayConfig;
-use tenet_crypto::simulation::{
+use tenet::relay::RelayConfig;
+use tenet::simulation::{
     build_simulation_inputs, FriendsPerNode, MessageSizeDistribution, OnlineAvailability,
     PlannedSend, PostFrequency, SimMessage, SimulationConfig, SimulationHarness, start_relay,
 };
@@ -14,6 +14,8 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
         max_messages: 100,
         max_bytes: 1024 * 1024,
         retry_backoff: Vec::new(),
+        peer_log_window: Duration::from_secs(60),
+        peer_log_interval: Duration::from_secs(30),
     })
     .await;
 


### PR DESCRIPTION
### Motivation
- Provide ready-to-run simulation scenarios and document the TOML format so runs can be driven from scenario files instead of only tests.
- Improve relay observability by logging peer connections and message sends and by emitting periodic summaries of recent peer connections.
- Make the toy UI more usable as an interactive debugger with readline support and non-fatal errors, and align binary names with the `tenet` naming scheme.

### Description
- Rename the crate and binaries in `Cargo.toml` and update invocations and imports so binaries are `tenet`, `tenet-sim`, `tenet-debugger`, and `tenet-relay`, and expose a `tenet` library crate.
- Add clustering support to the simulation by introducing `ClusteringConfig`, `clustering` in `SimulationConfig`, a clustered friend-graph builder `build_clustered_friend_graph`, and helper `sample_friends_target` in `src/simulation.rs`.
- Add scenario documentation at `docs/simulation.md` and two sample TOML scenarios: `scenarios/small_dense_6.toml` and `scenarios/large_clustered_100.toml`, and update `README.md` with usage examples for `tenet-sim`.
- Add relay peer and message logging in `src/relay.rs` including `record_peer_connection`, message-send prints, and a periodic summary task (`start_peer_log_task`) controlled by `peer_log_window` and `peer_log_interval` in `RelayConfig` and TOML mapping in `RelayConfigToml`.
- Wire the relay logging task into the relay entrypoints by calling `start_peer_log_task` from `src/bin/relay.rs` and the in-process relay used by simulation in `src/simulation.rs`.
- Upgrade the toy UI to use `rustyline` for a readline-style REPL with a colored prompt and history, and change command handling to print errors instead of exiting on unknown commands in `src/bin/toy_ui.rs`.
- Add `rustyline` to `Cargo.toml` and update tests and code references to the new crate name `tenet` across `src/*` and `tests/*`.

### Testing
- Ran `cargo check -q` which completed successfully though the build emitted some non-critical warnings about unused fields; no test failures were observed during the check.
- Existing integration test harness remains runnable via `cargo test --test simulation_harness_tests` and sample scenarios were added under `scenarios/` for manual `tenet-sim` runs (e.g. `cargo run --bin tenet-sim -- scenarios/small_dense_6.toml`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9083fca48325af39113bf4b51d65)