### PR TITLE
Add missing `clustering` field to simulation test config

### DIFF
--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -27,6 +27,7 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
         ],
         steps: 6,
         friends_per_node: FriendsPerNode::Uniform { min: 2, max: 2 },
+        clustering: None,
         post_frequency: PostFrequency::WeightedSchedule {
             weights: vec![1.0, 1.0, 2.0, 1.0, 0.5, 0.5],
             total_posts: 3,


### PR DESCRIPTION
### Motivation
- The `SimulationConfig` struct gained a new `clustering` field and the test initializer in `tests/simulation_harness_tests.rs` failed to compile due to the missing field.

### Description
- Add `clustering: None` to the `SimulationConfig` initializer in `tests/simulation_harness_tests.rs` to match the updated struct signature.

### Testing
- No automated tests were run as part of this change (`cargo test` was not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9770db748325a3fca238ed15f90d)