### PR TITLE
Make simulation encryption-aware and use protocol payload primitives

### DIFF
--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -30,6 +30,7 @@ the relay.
 - `availability`: online/offline behavior (see below).
 - `message_size_distribution`: message size generator (see below).
 - `clustering` (optional): cluster layout for dense subgraphs with sparse cross-links.
+- `encryption` (optional): message payload handling (`plaintext` or `encrypted`).
 
 ### `friends_per_node`
 
@@ -110,6 +111,18 @@ mean = 3.2
 std_dev = 0.7
 min = 40
 max = 400
+```
+
+### `encryption` (optional)
+
+```toml
+[simulation.encryption]
+type = "plaintext"
+```
+
+```toml
+[simulation.encryption]
+type = "encrypted"
 ```
 
 ### `clustering` (optional)

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -1,23 +1,25 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
+use tenet::protocol::{build_plaintext_payload, ContentId};
 use tenet::relay::RelayConfig;
 use tenet::simulation::{
-    build_simulation_inputs, FriendsPerNode, MessageSizeDistribution, OnlineAvailability,
-    PlannedSend, PostFrequency, SimMessage, SimulationConfig, SimulationHarness, start_relay,
+    build_simulation_inputs, start_relay, FriendsPerNode, MessageEncryption,
+    MessageSizeDistribution, OnlineAvailability, PlannedSend, PostFrequency, SimMessage,
+    SimulationConfig, SimulationHarness,
 };
 
 #[tokio::test]
 async fn simulation_harness_routes_relay_and_direct_with_dedup() {
-    let (base_url, shutdown_tx) = start_relay(RelayConfig {
+    let relay_config = RelayConfig {
         ttl: Duration::from_secs(5),
         max_messages: 100,
         max_bytes: 1024 * 1024,
         retry_backoff: Vec::new(),
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
-    })
-    .await;
+    };
+    let (base_url, shutdown_tx) = start_relay(relay_config.clone()).await;
 
     let config = SimulationConfig {
         node_ids: vec![
@@ -34,29 +36,46 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
         },
         availability: OnlineAvailability::Bernoulli { p_online: 1.0 },
         message_size_distribution: MessageSizeDistribution::Uniform { min: 8, max: 32 },
+        encryption: Some(MessageEncryption::Plaintext),
         seed: 42,
     };
 
     let inputs = build_simulation_inputs(&config);
-    let mut harness = SimulationHarness::new(base_url, inputs.nodes, inputs.direct_links, true);
+    let mut harness = SimulationHarness::new(
+        base_url,
+        inputs.nodes,
+        inputs.direct_links,
+        true,
+        relay_config.ttl.as_secs(),
+        inputs.encryption,
+        inputs.keypairs,
+    );
 
     let mut planned = inputs.planned_sends;
+    let payload = build_plaintext_payload("relay me", b"message-a");
+    let message_id = ContentId::from_value(&payload).expect("serialize plaintext payload");
+    let message_a_id = message_id.0.clone();
     planned.push(PlannedSend {
         step: 0,
         message: SimMessage {
-            id: "message-a".to_string(),
+            id: message_id.0,
             sender: "node-a".to_string(),
             recipient: "node-b".to_string(),
             body: "relay me".to_string(),
+            payload,
         },
     });
+    let payload = build_plaintext_payload("direct and relay", b"message-c");
+    let message_id = ContentId::from_value(&payload).expect("serialize plaintext payload");
+    let message_c_id = message_id.0.clone();
     planned.push(PlannedSend {
         step: 2,
         message: SimMessage {
-            id: "message-c".to_string(),
+            id: message_id.0,
             sender: "node-c".to_string(),
             recipient: "node-b".to_string(),
             body: "direct and relay".to_string(),
+            payload,
         },
     });
 
@@ -67,6 +86,6 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
     let mut ids: HashSet<String> = inbox.iter().map(|message| message.id.clone()).collect();
 
     assert_eq!(ids.len(), inbox.len());
-    assert!(ids.remove("message-a"));
-    assert!(ids.remove("message-c"));
+    assert!(ids.remove(&message_a_id));
+    assert!(ids.remove(&message_c_id));
 }


### PR DESCRIPTION
### Motivation
- Ensure the simulation uses the library protocol types and deterministic content IDs to avoid ad-hoc/duplicated envelope and payload logic.
- Support exercising real encryption paths in the harness so simulated messages can be encrypted and decrypted as in the real system.
- Provide a single, reliable plaintext payload builder that avoids collisions by salting IDs and add core helpers for constructing encrypted payloads.

### Description
- Add protocol helpers and types in `src/protocol.rs`: `PLAINTEXT_CONTENT_TYPE`, `ENCRYPTED_CONTENT_TYPE`, `build_plaintext_payload`, `build_encrypted_payload`, `decrypt_encrypted_payload`, `WrappedKeyPayload`, `EncryptedPayload`, and `PayloadCryptoError`, and ensure `build_envelope_from_payload` derives message IDs from payload content.
- Wire simulation to use protocol `Payload`/`Envelope` types by storing a `Payload` on `SimMessage`, adding `MessageEncryption` to `SimulationConfig`, carrying `keypairs` in `SimulationInputs`, and making `SimulationHarness` optionally encrypt/decrypt payloads via `decode_envelope`, `deliver_direct`, and `build_message_payload`.
- Add deterministic keypair generation helper `generate_keypair_with_rng` in `src/crypto.rs` and use a seeded crypto RNG in the harness to produce reproducible test key material; reuse existing crypto primitives (`encrypt_payload`, `wrap_content_key`, `unwrap_content_key`, `decrypt_payload`) from `crypto` for payload construction and decryption.
- Update docs and tests: add `encryption` option to `docs/simulation.md` and update `tests/simulation_harness_tests.rs` to use the new plaintext helper and protocol-derived message IDs.

### Testing
- Ran code formatting with `cargo fmt` and `rustfmt --edition 2021` on modified files, which completed successfully.
- No automated unit or integration test suite (`cargo test`) was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a98e10b2083259e04ada61afcbf5a)