### PR TITLE
Fix simulation borrow errors and relay config usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Agent Instructions
+
+## Repository Overview
+Tenet is a Rust reference implementation of a peer-to-peer social network protocol concept. It includes:
+- Core library and binaries in `src/` for the CLI, relay service, debugger UI, and simulation tools.
+- Documentation in `docs/` covering architecture, MVP scope, and simulation guidance.
+- Scenario fixtures in `scenarios/` used by the simulation harness.
+- Tests in `tests/` and integration tests for the simulation harness.
+
+If the repository structure, purpose, or key components change substantially, update this overview to match.
+
+## Required Pre-Completion Checklist
+Before finishing any change, always run these steps to prevent breakages:
+1. Format the codebase: `cargo fmt`
+2. Ensure the project builds: `cargo build`
+3. Run the test suite: `cargo test`
+
+These checks must be completed for every change before you finalize your work.


### PR DESCRIPTION
### Motivation
- Resolve borrow/move errors that occurred when decoding envelopes while also mutably borrowing node state during simulation inbox processing. 
- Ensure direct delivery path does not conflict with mutable borrows when delivering to recipient nodes. 
- Preserve relay TTL access when starting relay instances from scenario config.

### Description
- Decode envelopes before mutably borrowing nodes in inbox processing loops in `SimulationHarness::run` and `run_with_progress` to avoid immutable/mutable borrow conflicts. 
- Rework `route_message` to build the envelope up front and decode it for direct delivery before mutably accessing the recipient node, and remove the previous `deliver_direct` helper usage. 
- Clone the relay TOML config before converting with `into_relay_config()` and use the cloned `ttl_seconds` when constructing the `SimulationHarness`.

### Testing
- Ran `cargo fmt` successfully. 
- Ran `cargo build` successfully (build completed with warnings). 
- Ran `cargo test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa289a6ac8325935e5990716cc5cd)