### PR TITLE
Implement simulation online handshake and meta message types

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,6 +119,8 @@ conversation or feed.
   * Per-recipient storage cap (e.g., max total bytes per user).
   * Per-sender rate limits to mitigate spam.
   * TTL enforced; expired data is removed without notice.
+  * Relay TTLs are intentionally short (default 3600s in the simulation scenarios) and should
+    remain within protocol bounds (1s minimum, 7 days maximum).
 * **Index bounds**: dedup index pruned alongside feed compaction.
 
 ## Getting Started (Rust)

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -151,4 +151,5 @@ peer_log_interval_seconds = 30
 ```
 
 The relay logging fields are optional; when omitted they default to a 60-second window with a
-30-second summary interval.
+30-second summary interval. Relay TTLs are meant to be short-lived; the sample default is 3600s,
+and values must stay within protocol bounds (1s minimum, 7 days maximum).


### PR DESCRIPTION
### Motivation
- Add lightweight metadata messages to support presence/handshake and missed-message recovery in the simulation harness. 
- Model a short, configurable relay TTL window and track handshake-related metrics to evaluate startup behavior and missed-message delivery. 

### Description
- Added `MetaMessage` enum and helpers (`build_meta_payload`, `decode_meta_payload`) and a `META_CONTENT_TYPE` constant to `src/protocol.rs` to represent `online`, `ack`, and `message_request` metadata messages. 
- Implemented an online startup flow in `src/simulation.rs` that: fetches relay inbox for peers when they come online, broadcasts `online` meta messages to neighbors, accepts `ack` within a configurable simulated window, issues `message_request` for peers that ack using per-peer last-seen timestamps, and delivers missed messages from an internal history. 
- Treated relay TTL as a short, configurable window and documented defaults and protocol bounds (1s minimum, 7 days maximum) in `docs/simulation.md` and `docs/architecture.md`. 
- Added handshake and recovery metrics to the simulation report and tracker: `online_broadcasts_sent`, `acks_received`, `missed_message_requests_sent`, and `missed_message_deliveries`. 
- Added simulation tests in `tests/simulation_harness_tests.rs` that validate the handshake sequence and missed-message retrieval behavior. 

### Testing
- Ran formatting: `cargo fmt` (success). 
- Built the project: `cargo build` (success). 
- Ran the test suite: `cargo test` (all tests passed, including the new `simulation_harness_tracks_online_handshake_metrics` and `simulation_harness_delivers_missed_messages_after_handshake` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ab5c5a7a48325a682bb725843d326)