### PR TITLE
Keep simulation TUI open until quit

### DIFF
--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -153,3 +153,9 @@ peer_log_interval_seconds = 30
 The relay logging fields are optional; when omitted they default to a 60-second window with a
 30-second summary interval. Relay TTLs are meant to be short-lived; the sample default is 3600s,
 and values must stay within protocol bounds (1s minimum, 7 days maximum).
+
+## Manual TUI test
+
+1. Run a simulation with the TUI enabled: `cargo run --bin tenet-sim -- --tui scenarios/basic.toml`.
+2. Wait for the simulation to complete and confirm the status panel displays the completion prompt.
+3. Press `q` and confirm the TUI exits back to the terminal.


### PR DESCRIPTION
### Motivation

- Keep the TUI visible after a simulation finishes so the user can inspect the final metrics before closing the terminal.
- Allow the user to explicitly exit the TUI by pressing `q` instead of the TUI automatically closing on completion.

### Description

- Updated `src/bin/simulation.rs` to import `crossterm::event::{self, Event, KeyCode}` and to track the last progress update with `last_update: Option<SimulationStepUpdate>`.
- Changed the `render` function signature to accept a `status: &str` and updated the status panel text to show running/completion messages.
- After the simulation task completes the TUI now renders a completion view (falling back to a constructed `SimulationStepUpdate` if none received) and calls `wait_for_quit()` which loops on `event::read()` until the user presses `q`.
- Documented manual TUI verification steps by adding a `Manual TUI test` section to `docs/simulation.md` describing how to run the TUI and exit with `q`.

### Testing

- Ran `cargo fmt` successfully to format changes.
- Ran `cargo build` successfully and the project compiled with expected warnings.
- Ran `cargo test` and the test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696abb337ea88325bc9fa1f8516e8051)