### PR TITLE
Add peer store-and-forward (store_for_peer) message kind and simulation support

### DIFF
--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -20,6 +20,51 @@ relay used during the run. You can find ready-made scenarios in `scenarios/`.
 `direct_enabled` is optional. When omitted the simulation uses direct delivery links in addition to
 the relay.
 
+## Store-and-forward example
+
+To exercise peer-assisted store-and-forward, use a small encrypted scenario with three nodes.
+When node B is offline, node A will wrap the message for storage at node C and C will forward it
+once B comes online.
+
+```toml
+[simulation]
+node_ids = ["node-a", "node-b", "node-c"]
+steps = 20
+seed = 7
+
+[simulation.friends_per_node]
+type = "uniform"
+min = 2
+max = 2
+
+[simulation.post_frequency]
+type = "weighted_schedule"
+weights = [1, 1, 1, 2, 1]
+total_posts = 6
+
+[simulation.availability]
+type = "markov"
+p_online_given_online = 0.7
+p_online_given_offline = 0.2
+start_online_prob = 0.4
+
+[simulation.message_size_distribution]
+type = "uniform"
+min = 20
+max = 80
+
+[simulation.encryption]
+type = "encrypted"
+
+[relay]
+ttl_seconds = 3600
+max_messages = 200
+max_bytes = 1048576
+retry_backoff_seconds = [1, 2, 4]
+```
+
+The full scenario is available as `scenarios/store_and_forward_3.toml`.
+
 ## `[simulation]` fields
 
 - `node_ids` (array of strings): IDs to use for simulated peers.

--- a/scenarios/store_and_forward_3.toml
+++ b/scenarios/store_and_forward_3.toml
@@ -1,0 +1,34 @@
+[simulation]
+node_ids = ["node-a", "node-b", "node-c"]
+steps = 20
+seed = 7
+
+[simulation.friends_per_node]
+type = "uniform"
+min = 2
+max = 2
+
+[simulation.post_frequency]
+type = "weighted_schedule"
+weights = [1, 1, 1, 2, 1]
+total_posts = 6
+
+[simulation.availability]
+type = "markov"
+p_online_given_online = 0.7
+p_online_given_offline = 0.2
+start_online_prob = 0.4
+
+[simulation.message_size_distribution]
+type = "uniform"
+min = 20
+max = 80
+
+[simulation.encryption]
+type = "encrypted"
+
+[relay]
+ttl_seconds = 3600
+max_messages = 200
+max_bytes = 1048576
+retry_backoff_seconds = [1, 2, 4]

--- a/src/bin/toy_ui.rs
+++ b/src/bin/toy_ui.rs
@@ -401,6 +401,8 @@ fn build_envelope(
     let mut header = Header {
         sender_id: sender.keypair.id.clone(),
         recipient_id: recipient_id.to_string(),
+        store_for: None,
+        storage_peer_id: None,
         timestamp,
         message_id,
         message_kind: MessageKind::Direct,


### PR DESCRIPTION
### Motivation

- Add a peer-assisted store-and-forward flow so senders can ask a mutual friend to hold an encrypted copy for an offline recipient until the recipient comes online. 
- Track store-and-forward usage in the simulation to measure stored, forwarded, and delivered-through-peer counts and validate behavior.

### Description

- Protocol: introduce `MessageKind::StoreForPeer` and add `store_for` and `storage_peer_id` header fields with validation and canonical signing support, and extend `build_envelope_from_payload` / plaintext helpers to carry these fields. 
- Simulation: implement encoding/decoding and handling for store-for-peer envelopes, including wrapping an inner direct envelope in an encrypted outer payload targeted at a storage peer, selecting a mutual friend as storage peer when recipient is offline, storing the inner envelope on the storage peer, and forwarding it when the final recipient becomes online. 
- Metrics: add `store_forwards_stored`, `store_forwards_forwarded`, and `store_forwards_delivered` to `SimulationMetrics` and `MetricsTracker` and increment them at the appropriate points. 
- Docs & fixtures: document the new flow in `docs/architecture.md` and `docs/simulation.md`, add a runnable scenario `scenarios/store_and_forward_3.toml`, and update a small UI helper to initialize new header fields.

### Testing

- Ran formatting with `cargo fmt`. (completed)
- Built the project with `cargo build` (succeeded with warnings). 
- Ran the test suite with `cargo test` and all automated tests passed (`unit` and simulation harness tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696abac1a2d483258998c32143286790)