### PR TITLE
Show relay logs in the simulation TUI

### DIFF
--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -18,6 +18,7 @@ async fn main() {
         }),
         peer_log_window: Duration::from_secs(env_u64("TENET_RELAY_PEER_LOG_WINDOW_SECS", 60)),
         peer_log_interval: Duration::from_secs(env_u64("TENET_RELAY_PEER_LOG_INTERVAL_SECS", 30)),
+        log_sink: None,
     };
 
     let state = RelayState::new(config);

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -125,6 +125,7 @@ impl RelayConfigToml {
                 .collect(),
             peer_log_window: Duration::from_secs(self.peer_log_window_seconds.unwrap_or(60)),
             peer_log_interval: Duration::from_secs(self.peer_log_interval_seconds.unwrap_or(30)),
+            log_sink: None,
         }
     }
 }

--- a/tests/relay_tests.rs
+++ b/tests/relay_tests.rs
@@ -95,6 +95,7 @@ async fn relay_expires_messages_after_ttl() {
         retry_backoff: Vec::new(),
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
+        log_sink: None,
     })
     .await;
 
@@ -147,6 +148,7 @@ async fn relay_deduplicates_by_message_id() {
         retry_backoff: Vec::new(),
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
+        log_sink: None,
     })
     .await;
 
@@ -200,6 +202,7 @@ async fn node_can_send_and_receive_through_relay() {
         retry_backoff: Vec::new(),
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
+        log_sink: None,
     })
     .await;
 

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -18,6 +18,7 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
         retry_backoff: Vec::new(),
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
+        log_sink: None,
     };
     let (base_url, shutdown_tx) = start_relay(relay_config.clone()).await;
 
@@ -99,6 +100,7 @@ async fn simulation_harness_tracks_online_handshake_metrics() {
         retry_backoff: Vec::new(),
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
+        log_sink: None,
     };
     let (base_url, shutdown_tx) = start_relay(relay_config.clone()).await;
 
@@ -139,6 +141,7 @@ async fn simulation_harness_delivers_missed_messages_after_handshake() {
         retry_backoff: Vec::new(),
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
+        log_sink: None,
     };
     let (base_url, shutdown_tx) = start_relay(relay_config.clone()).await;
 


### PR DESCRIPTION
### Motivation
- Relay prints to stdout during simulation which corrupts the tui display; logs need to be routed into the TUI for proper rendering.
- Provide a way for callers to capture relay log lines instead of always using `println!` so different UIs can consume logs.

### Description
- Add an optional `log_sink: Option<Arc<dyn Fn(String) + Send + Sync>>` to `RelayConfig` and thread it through `RelayState` so relay code can emit logs via a sink instead of `println!` (see `src/relay.rs`).
- Replace direct `println!` calls in the relay with a helper `log_message` that invokes the configured `log_sink` or falls back to `println!`.
- Update `RelayConfigToml::into_relay_config` and the relay binary to default `log_sink` to `None`, and update tests that construct `RelayConfig` to set `log_sink: None`.
- In the simulation TUI (`src/bin/simulation.rs`) create an mpsc channel for relay log lines, set the relay config `log_sink` to forward lines into that channel, accumulate recent lines (bounded by `RELAY_LOG_LIMIT`) and render them in a new "Relay Logs" panel inside the TUI while the simulation runs.

### Testing
- Ran formatting with `cargo fmt` successfully.
- Built the project with `cargo build` and the build completed with warnings only.
- Ran the test suite with `cargo test` and all unit and integration tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696abda687bc8325b74fbc89389374ca)