### PR TITLE
Add simulated-time settings, cohort-based online schedules, and simulated-time metrics to simulations

### DIFF
--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -32,6 +32,10 @@ node_ids = ["node-a", "node-b", "node-c"]
 steps = 20
 seed = 7
 
+[simulation.simulated_time]
+seconds_per_step = 300
+default_speed_factor = 1.0
+
 [simulation.friends_per_node]
 type = "uniform"
 min = 2
@@ -39,14 +43,27 @@ max = 2
 
 [simulation.post_frequency]
 type = "weighted_schedule"
-weights = [1, 1, 1, 2, 1]
+weights = [0.2, 0.15, 0.1, 0.1, 0.15, 0.3, 0.5, 0.7, 0.9, 1.0, 1.0, 0.95, 0.9, 0.8, 0.75, 0.8, 0.9, 1.0, 0.95, 0.8, 0.6, 0.45, 0.3, 0.25]
 total_posts = 6
 
-[simulation.availability]
-type = "markov"
-p_online_given_online = 0.7
-p_online_given_offline = 0.2
-start_online_prob = 0.4
+[[simulation.cohorts]]
+name = "always-online"
+type = "always_online"
+share = 0.25
+
+[[simulation.cohorts]]
+name = "rarely-online"
+type = "rarely_online"
+share = 0.35
+online_probability = 0.2
+
+[[simulation.cohorts]]
+name = "diurnal"
+type = "diurnal"
+share = 0.4
+online_probability = 0.75
+timezone_offset_hours = -5
+hourly_weights = [0.2, 0.15, 0.1, 0.1, 0.15, 0.3, 0.5, 0.7, 0.9, 1.0, 1.0, 0.95, 0.9, 0.8, 0.75, 0.8, 0.9, 1.0, 0.95, 0.8, 0.6, 0.45, 0.3, 0.25]
 
 [simulation.message_size_distribution]
 type = "uniform"
@@ -70,9 +87,11 @@ The full scenario is available as `scenarios/store_and_forward_3.toml`.
 - `node_ids` (array of strings): IDs to use for simulated peers.
 - `steps` (integer): number of simulation steps.
 - `seed` (integer): RNG seed.
+- `simulated_time` (optional): simulated-time settings (see below).
 - `friends_per_node`: friend graph distribution (see below).
 - `post_frequency`: how often each node posts (see below).
-- `availability`: online/offline behavior (see below).
+- `availability` (optional): legacy online/offline behavior when no cohorts are defined.
+- `cohorts` (optional): cohort definitions for online behavior (see below).
 - `message_size_distribution`: message size generator (see below).
 - `clustering` (optional): cluster layout for dense subgraphs with sparse cross-links.
 - `encryption` (optional): message payload handling (`plaintext` or `encrypted`).
@@ -104,8 +123,10 @@ exponent = 1.2
 ```toml
 [simulation.post_frequency]
 type = "poisson"
-lambda_per_step = 0.4
+lambda_per_hour = 0.4
 ```
+
+`lambda_per_step` is still supported for legacy scenarios without simulated-time settings.
 
 ```toml
 [simulation.post_frequency]
@@ -114,6 +135,8 @@ weights = [1, 1, 2, 3, 5]
 # total posts per node
 total_posts = 20
 ```
+
+When `weights` contains 24 entries, they are treated as hourly weights over a simulated day.
 
 ### `availability`
 
@@ -129,6 +152,41 @@ type = "markov"
 p_online_given_online = 0.92
 p_online_given_offline = 0.25
 start_online_prob = 0.8
+```
+
+### `simulated_time` (optional)
+
+```toml
+[simulation.simulated_time]
+seconds_per_step = 300
+default_speed_factor = 1.0
+```
+
+### `cohorts` (optional)
+
+```toml
+[[simulation.cohorts]]
+name = "always-online"
+type = "always_online"
+share = 0.2
+```
+
+```toml
+[[simulation.cohorts]]
+name = "rarely-online"
+type = "rarely_online"
+share = 0.5
+online_probability = 0.1
+```
+
+```toml
+[[simulation.cohorts]]
+name = "diurnal"
+type = "diurnal"
+share = 0.3
+online_probability = 0.7
+timezone_offset_hours = 2
+hourly_weights = [0.2, 0.15, 0.1, 0.1, 0.15, 0.3, 0.5, 0.7, 0.9, 1.0, 1.0, 0.95, 0.9, 0.8, 0.75, 0.8, 0.9, 1.0, 0.95, 0.8, 0.6, 0.45, 0.3, 0.25]
 ```
 
 ### `message_size_distribution`

--- a/scenarios/large_clustered_100.toml
+++ b/scenarios/large_clustered_100.toml
@@ -3,6 +3,10 @@ node_ids = ["node-1", "node-2", "node-3", "node-4", "node-5", "node-6", "node-7"
 steps = 200
 seed = 1337
 
+[simulation.simulated_time]
+seconds_per_step = 300
+default_speed_factor = 1.0
+
 [simulation.friends_per_node]
 type = "uniform"
 min = 2
@@ -14,13 +18,26 @@ inter_cluster_friend_probability = 0.015
 
 [simulation.post_frequency]
 type = "poisson"
-lambda_per_step = 0.35
+lambda_per_hour = 4.2
 
-[simulation.availability]
-type = "markov"
-p_online_given_online = 0.92
-p_online_given_offline = 0.25
-start_online_prob = 0.8
+[[simulation.cohorts]]
+name = "always-online"
+type = "always_online"
+share = 0.15
+
+[[simulation.cohorts]]
+name = "rarely-online"
+type = "rarely_online"
+share = 0.45
+online_probability = 0.18
+
+[[simulation.cohorts]]
+name = "diurnal"
+type = "diurnal"
+share = 0.4
+online_probability = 0.75
+timezone_offset_hours = 1
+hourly_weights = [0.2, 0.15, 0.1, 0.1, 0.15, 0.3, 0.5, 0.7, 0.9, 1.0, 1.0, 0.95, 0.9, 0.8, 0.75, 0.8, 0.9, 1.0, 0.95, 0.8, 0.6, 0.45, 0.3, 0.25]
 
 [simulation.message_size_distribution]
 type = "log_normal"

--- a/scenarios/small_dense_6.toml
+++ b/scenarios/small_dense_6.toml
@@ -3,6 +3,10 @@ node_ids = ["node-1", "node-2", "node-3", "node-4", "node-5", "node-6"]
 steps = 60
 seed = 42
 
+[simulation.simulated_time]
+seconds_per_step = 300
+default_speed_factor = 1.0
+
 [simulation.friends_per_node]
 type = "uniform"
 min = 4
@@ -10,11 +14,26 @@ max = 5
 
 [simulation.post_frequency]
 type = "poisson"
-lambda_per_step = 0.6
+lambda_per_hour = 7.0
 
-[simulation.availability]
-type = "bernoulli"
-p_online = 0.9
+[[simulation.cohorts]]
+name = "always-online"
+type = "always_online"
+share = 0.25
+
+[[simulation.cohorts]]
+name = "rarely-online"
+type = "rarely_online"
+share = 0.35
+online_probability = 0.2
+
+[[simulation.cohorts]]
+name = "diurnal"
+type = "diurnal"
+share = 0.4
+online_probability = 0.7
+timezone_offset_hours = -4
+hourly_weights = [0.2, 0.15, 0.1, 0.1, 0.15, 0.3, 0.5, 0.7, 0.9, 1.0, 1.0, 0.95, 0.9, 0.8, 0.75, 0.8, 0.9, 1.0, 0.95, 0.8, 0.6, 0.45, 0.3, 0.25]
 
 [simulation.message_size_distribution]
 type = "uniform"

--- a/scenarios/store_and_forward_3.toml
+++ b/scenarios/store_and_forward_3.toml
@@ -3,6 +3,10 @@ node_ids = ["node-a", "node-b", "node-c"]
 steps = 20
 seed = 7
 
+[simulation.simulated_time]
+seconds_per_step = 300
+default_speed_factor = 1.0
+
 [simulation.friends_per_node]
 type = "uniform"
 min = 2
@@ -10,14 +14,27 @@ max = 2
 
 [simulation.post_frequency]
 type = "weighted_schedule"
-weights = [1, 1, 1, 2, 1]
+weights = [0.2, 0.15, 0.1, 0.1, 0.15, 0.3, 0.5, 0.7, 0.9, 1.0, 1.0, 0.95, 0.9, 0.8, 0.75, 0.8, 0.9, 1.0, 0.95, 0.8, 0.6, 0.45, 0.3, 0.25]
 total_posts = 6
 
-[simulation.availability]
-type = "markov"
-p_online_given_online = 0.7
-p_online_given_offline = 0.2
-start_online_prob = 0.4
+[[simulation.cohorts]]
+name = "always-online"
+type = "always_online"
+share = 0.3
+
+[[simulation.cohorts]]
+name = "rarely-online"
+type = "rarely_online"
+share = 0.3
+online_probability = 0.2
+
+[[simulation.cohorts]]
+name = "diurnal"
+type = "diurnal"
+share = 0.4
+online_probability = 0.8
+timezone_offset_hours = -5
+hourly_weights = [0.2, 0.15, 0.1, 0.1, 0.15, 0.3, 0.5, 0.7, 0.9, 1.0, 1.0, 0.95, 0.9, 0.8, 0.75, 0.8, 0.9, 1.0, 0.95, 0.8, 0.6, 0.45, 0.3, 0.25]
 
 [simulation.message_size_distribution]
 type = "uniform"

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -76,12 +76,7 @@ fn header_roundtrips_and_validates_message_kinds() {
         (MessageKind::Public, None, None, None),
         (MessageKind::Meta, None, None, None),
         (MessageKind::Direct, None, None, None),
-        (
-            MessageKind::FriendGroup,
-            Some("group-42"),
-            None,
-            None,
-        ),
+        (MessageKind::FriendGroup, Some("group-42"), None, None),
         (
             MessageKind::StoreForPeer,
             None,

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use tenet::protocol::{build_plaintext_payload, ContentId};
@@ -6,7 +6,7 @@ use tenet::relay::RelayConfig;
 use tenet::simulation::{
     build_simulation_inputs, start_relay, FriendsPerNode, MessageEncryption,
     MessageSizeDistribution, OnlineAvailability, PlannedSend, PostFrequency, SimMessage,
-    SimulationConfig, SimulationHarness,
+    SimulatedTimeConfig, SimulationConfig, SimulationHarness,
 };
 
 #[tokio::test]
@@ -28,13 +28,18 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
             "node-c".to_string(),
         ],
         steps: 6,
+        simulated_time: SimulatedTimeConfig {
+            seconds_per_step: 60,
+            default_speed_factor: 1.0,
+        },
         friends_per_node: FriendsPerNode::Uniform { min: 2, max: 2 },
         clustering: None,
         post_frequency: PostFrequency::WeightedSchedule {
             weights: vec![1.0, 1.0, 2.0, 1.0, 0.5, 0.5],
             total_posts: 3,
         },
-        availability: OnlineAvailability::Bernoulli { p_online: 1.0 },
+        availability: Some(OnlineAvailability::Bernoulli { p_online: 1.0 }),
+        cohorts: Vec::new(),
         message_size_distribution: MessageSizeDistribution::Uniform { min: 8, max: 32 },
         encryption: Some(MessageEncryption::Plaintext),
         seed: 42,
@@ -49,6 +54,8 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
         relay_config.ttl.as_secs(),
         inputs.encryption,
         inputs.keypairs,
+        60.0,
+        inputs.cohort_online_rates,
     );
 
     let mut planned = inputs.planned_sends;
@@ -118,6 +125,8 @@ async fn simulation_harness_tracks_online_handshake_metrics() {
         relay_config.ttl.as_secs(),
         MessageEncryption::Plaintext,
         Default::default(),
+        60.0,
+        HashMap::new(),
     );
 
     harness.run(2, Vec::new()).await;
@@ -158,6 +167,8 @@ async fn simulation_harness_delivers_missed_messages_after_handshake() {
         relay_config.ttl.as_secs(),
         MessageEncryption::Plaintext,
         Default::default(),
+        60.0,
+        HashMap::new(),
     );
 
     let payload = build_plaintext_payload("missed", b"missed-message");


### PR DESCRIPTION
### Motivation

- Provide simulated-time semantics so scenarios can express hours/minutes per simulation step and schedule posts by simulated clock instead of uniform steps. 
- Model realistic availability with named cohorts (always-online, rarely-online, diurnal) and allow diurnal/hourly weighting to represent time-of-day behavior. 
- Expose metrics in simulated-time units and per-cohort online rates to help analyze delivery latency and reach under realistic availability patterns.

### Description

- Extended `SimulationConfig` with `simulated_time: SimulatedTimeConfig` and `cohorts: Vec<OnlineCohortDefinition>`, added `SimulatedTimeConfig` and cohort enums (`AlwaysOnline`, `RarelyOnline`, `Diurnal`).
- Reworked schedule generation: `build_online_schedules` now returns an `OnlineSchedulePlan` and generates per-node boolean schedules from cohorts (or falls back to legacy `availability`); added helper functions `build_cohort_schedule`, `build_availability_schedule`, `normalize_hourly_weights`, and cohort selection logic.
- Adjusted posting logic in `build_planned_sends` to support `lambda_per_hour` (converted to per-step using simulated seconds per step) and to treat 24-entry `weights` as hourly weights to sample simulated-time steps.
- Added simulated-time metrics and cohort rates: `MetricsTracker` now stores `simulated_seconds_per_step`, records latency histograms both in steps and converted to simulated seconds, and reports `cohort_online_rates` in `SimulationMetricsReport`.
- Updated `SimulationInputs`, `SimulationHarness::new` signature and usages to pass simulated-second conversion and cohort rates; updated tests to adapt to new API.
- Documentation and scenarios updated: `docs/simulation.md` documents `simulated_time`, cohort definitions and hourly weights; example scenario TOMLs in `scenarios/` were updated to demonstrate cohorts and hourly-weighted schedules.

### Testing

- Ran `cargo fmt` to format changes successfully. 
- Built the project with `cargo build`; build completed successfully but there are benign warnings about unused fields reported during compilation. 
- Ran the test suite with `cargo test`; all tests ran and succeeded (unit and integration tests passed) with the same warnings about unused fields noted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac0e5686483258e3a1d227f9df4bc)