### PR TITLE
Add interactive controls to simulation harness

### DIFF
--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -259,6 +259,15 @@ and values must stay within protocol bounds (1s minimum, 7 days maximum).
 
 ## Manual TUI test
 
+### TUI key bindings
+
+When running `tenet-sim --tui`, use these keys to adjust the simulation while it runs:
+
+- `a`: add a peer (type an id, or press Enter for an auto-generated id).
+- `f`: add a friendship (enter two peer ids separated by space or comma).
+- `+` / `=`: speed up simulated time.
+- `-`: slow down simulated time.
+
 1. Run a simulation with the TUI enabled: `cargo run --bin tenet-sim -- --tui scenarios/basic.toml`.
 2. Wait for the simulation to complete and confirm the status panel displays the completion prompt.
 3. Press `q` and confirm the TUI exits back to the terminal.


### PR DESCRIPTION
### Motivation
- Allow runtime, non-blocking control of the simulation TUI so users can add peers, create friendships, and adjust simulated time speed while a run is in progress.
- Extend the harness inputs and progress updates so the TUI can reflect dynamic graph changes and current speed.

### Description
- Introduced `SimulationTimingConfig` and threaded it through `SimulationInputs` and `SimulationHarness` to represent base seconds-per-step, a runtime `speed_factor`, and an adjustable real-time delay per step (`real_time_per_step`).
- Added `SimulationControlCommand` (add peer, add friendship, adjust/set speed) and a control channel consumed by a new `run_with_progress_and_controls` method that applies dynamic updates via `apply_control_command` during the progress loop.
- Extended `SimulationStepUpdate` with `total_peers` and `speed_factor`, updated the harness to populate those fields and optionally sleep per-step according to the runtime speed.
- Implemented a non-blocking TUI input loop in `src/bin/simulation.rs` with an input thread, key handling, and status messages; keys include `a` (add peer), `f` (add friendship), `+`/`=` (speed up) and `-` (slow down), and TUI now displays total peers and speed.
- Documented the TUI key bindings in `docs/simulation.md` and added an integration-style test `simulation_harness_applies_dynamic_updates` to validate dynamic updates don't break invariants.

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo build`; build succeeded with a small number of non-critical warnings about unused fields.
- Ran `cargo test`; the full test suite passed (including the new dynamic update test), all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac41da0448325971914e4cfd464ab)