### PR TITLE
Add aggregate simulation metrics, TUI display, and log id truncation

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -62,7 +62,7 @@ impl ProtocolVersion {
 }
 
 /// Types of messages supported by the protocol.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MessageKind {
     Public,

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -441,7 +441,9 @@ fn store_envelope_locked(
             config,
             format!(
                 "relay: message sent {} -> {} (message_id: {})",
-                sender_id, recipient_id, message_id
+                format_peer_id(&sender_id),
+                format_peer_id(&recipient_id),
+                format_message_id(&message_id)
             ),
         );
     } else {
@@ -449,7 +451,8 @@ fn store_envelope_locked(
             config,
             format!(
                 "relay: message sent -> {} (message_id: {})",
-                recipient_id, message_id
+                format_peer_id(&recipient_id),
+                format_message_id(&message_id)
             ),
         );
     }
@@ -513,7 +516,10 @@ fn record_peer_connection(
     };
     inner.peer_last_seen.insert(peer_id.to_string(), now);
     if should_log {
-        log_message(config, format!("relay: peer connected {}", peer_id));
+        log_message(
+            config,
+            format!("relay: peer connected {}", format_peer_id(peer_id)),
+        );
     }
 }
 
@@ -523,6 +529,20 @@ fn log_message(config: &RelayConfig, message: String) {
     } else {
         println!("{message}");
     }
+}
+
+const LOG_ID_TRUNCATE_LEN: usize = 7;
+
+fn format_peer_id(peer_id: &str) -> String {
+    format!("p-{}", truncate_id(peer_id))
+}
+
+fn format_message_id(message_id: &str) -> String {
+    format!("m-{}", truncate_id(message_id))
+}
+
+fn truncate_id(id: &str) -> String {
+    id.chars().take(LOG_ID_TRUNCATE_LEN).collect()
 }
 
 fn count_recent_peers(inner: &RelayStateInner, now: Instant, window: Duration) -> usize {


### PR DESCRIPTION
### Motivation

- Provide live aggregate metrics in the simulation TUI instead of only printing them after quit to avoid the post-exit hang and improve observability. 
- Track additional message-count and size statistics (per-peer and per-message-kind) required to analyze feed/store/forward behavior. 
- Shorten peer and message identifiers in relay logs for easier reading by truncating IDs with `p-`/`m-` prefixes.

### Description

- Added new aggregate metrics types `SimulationAggregateMetrics`, `CountSummary`, and `SizeSummary` and integrated them into `SimulationStepUpdate` and `SimulationMetricsReport` so step updates and final reports carry feed counts, per-kind sent counts, stored/unforwarded and forwarded counts, and message-size summaries.
- Extended `MetricsTracker` to record per-peer sent counts by `MessageKind`, per-peer forwarded store counts, and message-size statistics (`SizeStats`), and expose helper summary functions used when building aggregate metrics in `SimulationHarness::aggregate_metrics` and `metrics_report`.
- Updated the TUI (`src/bin/simulation.rs`) to render aggregate metrics live alongside step metrics, increased the layout to include an "Aggregate Metrics" panel, and added formatting helpers to display min/avg/max for counts and sizes in a compact form.
- Fixed the input polling and shutdown logic in the TUI by switching to a polled input loop with an `AtomicBool` shutdown flag so the input task cancels cleanly on exit (removing the hang after pressing `q`).
- Truncated IDs in relay logs by adding `format_peer_id` and `format_message_id` helpers (prefixing with `p-` and `m-` and truncating to a short length) and used these in log messages to make relay logs more compact.
- Small compatibility changes: made `MessageKind` `Hash`able so it can be used as keys in HashMaps, and wired message-kind iteration via `MESSAGE_KIND_SUMMARIES` / `MESSAGE_KIND_ORDER` for reliable ordering.

Files changed include `src/simulation.rs`, `src/bin/simulation.rs`, `src/relay.rs`, and `src/protocol.rs` among others.

### Testing

- Ran formatting with `cargo fmt` successfully. 
- Built the project with `cargo build` successfully (warnings only). 
- Ran the test-suite with `cargo test` and all automated tests passed (unit and integration tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696acd0f8ed88325a5c2ea6c2b76f33b)