### PR TITLE
Emit and track meta messages during simulation

### DIFF
--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -259,8 +259,10 @@ and values must stay within protocol bounds (1s minimum, 7 days maximum).
 
 ## Simulation metrics
 
-The simulation reports a `SimulationMetrics` struct with counters that track how messages move
-through the system. Each field increments in specific parts of the simulation loop:
+Running `tenet-sim` prints a `SimulationReport` JSON blob that includes both real-time counters
+(`metrics`) and aggregate summaries (`report`). The `metrics` section is a `SimulationMetrics`
+struct with counters that track how messages move through the system. Each field increments in
+specific parts of the simulation loop:
 
 - `planned_messages`: set to the number of planned sends (`plan.len()`) at the start of a run, so
   it reflects how many messages the scenario intended to send.
@@ -285,6 +287,20 @@ Common relationships to expect:
 - Store-and-forward counters typically decrease in order (`store_forwards_stored` ≥
   `store_forwards_forwarded` ≥ `store_forwards_delivered`) since forwarding and delivery depend on
   online peers and successful inbox delivery.
+
+The `report` section (`SimulationMetricsReport`) adds aggregate summaries:
+
+- `peer_feed_messages`: min/avg/max feed message counts per peer.
+- `stored_unforwarded_by_peer`: min/avg/max counts of stored-but-not-forwarded messages per peer.
+- `stored_forwarded_by_peer`: min/avg/max counts of stored-and-forwarded messages per peer.
+- `sent_messages_by_kind`: per message kind min/avg/max sent counts per peer.
+- `message_size_by_kind`: per message kind min/avg/max payload sizes in **bytes**.
+
+If a message kind has `no samples`, it means the scenario did not generate that kind. The current
+scenarios primarily emit direct messages and store-and-forward traffic, so `public` and
+`friend_group` kinds will remain at zero until scenarios start scheduling those messages. Meta
+messages are emitted for online broadcasts, acknowledgements, and missed-message requests; if the
+`meta` kind remains at zero it indicates a simulation bug rather than an optional feature.
 
 ## Manual TUI test
 

--- a/src/bin/simulation.rs
+++ b/src/bin/simulation.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), String> {
     } else {
         run_simulation_scenario(scenario).await?
     };
-    let output = serde_json::to_string_pretty(&report.metrics).map_err(|err| err.to_string())?;
+    let output = serde_json::to_string_pretty(&report).map_err(|err| err.to_string())?;
     println!("{output}");
     Ok(())
 }
@@ -419,7 +419,7 @@ fn format_size_summary(summary: &SizeSummary) -> String {
     };
     let min = summary.min.unwrap_or(0);
     let max = summary.max.unwrap_or(0);
-    format!("min {min} / avg {average:.2} / max {max}")
+    format!("min {min} bytes / avg {average:.2} bytes / max {max} bytes")
 }
 
 fn message_kind_label(kind: &MessageKind) -> &'static str {


### PR DESCRIPTION
### Motivation
- Meta messages for online broadcasts, acknowledgements, and missed-message requests are not optional and must be actually emitted and counted; zero `meta` samples indicate a simulation bug. 

### Description
- Send meta envelopes from the harness by adding `send_meta_message` and making `enqueue_online_broadcasts`, `process_pending_online_broadcasts`, and `handle_message_request` async so they build and post `MessageKind::Meta` envelopes when peers come online or ACK/REQUEST events occur. 
- Track meta traffic in aggregate metrics by adding `MetricsTracker::record_meta_send` which updates `per_peer_sent_by_kind` and records payload sizes into `message_sizes_by_kind`. 
- Ensure the CLI prints the full `SimulationReport` JSON (including aggregate summaries) and update docs to state that `meta` messages are always emitted and a zero count indicates a bug. 

### Testing
- Ran `cargo fmt` which succeeded. 
- Built the project with `cargo build` which succeeded with only non-blocking warnings. 
- Ran the test suite with `cargo test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad55b1450832590974722539c661c)