### PR TITLE
Improve simulation controls, timing, and logging

### DIFF
--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -30,6 +30,7 @@ once B comes online.
 [simulation]
 node_ids = ["node-a", "node-b", "node-c"]
 steps = 20
+duration_seconds = 6000
 seed = 7
 
 [simulation.simulated_time]
@@ -85,7 +86,10 @@ The full scenario is available as `scenarios/store_and_forward_3.toml`.
 ## `[simulation]` fields
 
 - `node_ids` (array of strings): IDs to use for simulated peers.
-- `steps` (integer): number of simulation steps.
+- `steps` (integer): number of simulation steps when `duration_seconds` is not provided.
+- `duration_seconds` (integer, optional): total simulated duration in seconds. When provided, the
+  simulation derives `steps` from `duration_seconds / simulated_time.seconds_per_step` (rounded up)
+  and uses that value for schedules and planned sends.
 - `seed` (integer): RNG seed.
 - `simulated_time` (optional): simulated-time settings (see below).
 - `friends_per_node`: friend graph distribution (see below).

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -32,6 +32,7 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
             "node-c".to_string(),
         ],
         steps: 6,
+        duration_seconds: None,
         simulated_time: SimulatedTimeConfig {
             seconds_per_step: 60,
             default_speed_factor: 1.0,
@@ -60,6 +61,7 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
         inputs.keypairs,
         inputs.timing,
         inputs.cohort_online_rates,
+        None,
     );
 
     let mut planned = inputs.planned_sends;
@@ -136,6 +138,7 @@ async fn simulation_harness_tracks_online_handshake_metrics() {
             base_real_time_per_step: Duration::ZERO,
         },
         HashMap::new(),
+        None,
     );
 
     harness.run(2, Vec::new()).await;
@@ -183,6 +186,7 @@ async fn simulation_harness_delivers_missed_messages_after_handshake() {
             base_real_time_per_step: Duration::ZERO,
         },
         HashMap::new(),
+        None,
     );
 
     let payload = build_plaintext_payload("missed", b"missed-message");
@@ -245,6 +249,7 @@ async fn simulation_harness_applies_dynamic_updates() {
             base_real_time_per_step: Duration::ZERO,
         },
         HashMap::new(),
+        None,
     );
 
     let (control_tx, control_rx) = mpsc::unbounded_channel();
@@ -257,7 +262,7 @@ async fn simulation_harness_applies_dynamic_updates() {
         peer_a: "node-a".to_string(),
         peer_b: "node-c".to_string(),
     });
-    let _ = control_tx.send(SimulationControlCommand::AdjustSpeedFactor { multiplier: 1.5 });
+    let _ = control_tx.send(SimulationControlCommand::AdjustSpeedFactor { delta: 0.5 });
     drop(control_tx);
 
     let mut last_update = None;


### PR DESCRIPTION
### Motivation

- Make the interactive simulation easier to control and suitable for fixed-duration runs by adding pause/quit, fixed speed increments, and duration-based scheduling.
- Surface simulation-level events (peer online/offline, store-forward/store/forward/deliver, handshake requests/acks) into logs so the TUI and automated runs can inspect what the simulation is doing.

### Description

- Add an optional `duration_seconds` to `SimulationConfig` and an `effective_steps()` helper that derives `steps` from `duration_seconds / simulated_time.seconds_per_step` when provided, and thread that through schedule and planned-send generation (`build_online_schedules`, `build_planned_sends`) and scenario runners (`run_simulation_scenario`, `run_simulation_scenario_with_progress`).
- Extend `SimulationControlCommand` with `AdjustSpeedFactor { delta: f64 }`, `SetPaused { paused: bool }`, and `Stop`, and change harness logic to apply a speed delta (additive +/−) instead of multiplicative scaling; harness now supports pause and stop and maintains a `log_sink` for simulation action logging.
- Add `log_action` calls across the harness to emit human-readable simulation events (peer came online/went offline, online announcements and acks, missed-message requests/deliveries, store-forward store/forward/deliver, speed changes, peer/friend additions).
- Update the TUI (`src/bin/simulation.rs`) to support: `q` to quit at any time, spacebar to toggle pause, `+`/`-` to change speed by `+0.10`/`-0.10`, streaming of relay and simulation logs into the UI, and wiring stop/pause commands into the control channel; add `InputAction` to return a quit action from key handling.
- Document `duration_seconds` in `docs/simulation.md` and adjust examples; update unit tests to accommodate constructor/signature changes.

### Testing

- Ran formatting with `cargo fmt` (completed successfully).
- Built the project with `cargo build` (completed successfully).
- Ran the test suite with `cargo test` and all tests passed (`tests/simulation_harness_tests` updated to match new signatures and passed along with other unit tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696adbfe9d248325bd12803e1e32e965)