### PR TITLE
Suppress relay logs while simulation is paused and collapse per-neighbor online announcements

### DIFF
--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -19,6 +19,7 @@ async fn main() {
         peer_log_window: Duration::from_secs(env_u64("TENET_RELAY_PEER_LOG_WINDOW_SECS", 60)),
         peer_log_interval: Duration::from_secs(env_u64("TENET_RELAY_PEER_LOG_INTERVAL_SECS", 30)),
         log_sink: None,
+        pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
     let state = RelayState::new(config);

--- a/src/bin/simulation.rs
+++ b/src/bin/simulation.rs
@@ -104,7 +104,8 @@ async fn run_with_tui(
     let scenario_for_task = scenario.clone();
     let total_steps = scenario_for_task.simulation.effective_steps();
     let sim_handle = tokio::spawn(async move {
-        let (base_url, shutdown_tx) = tenet::simulation::start_relay(relay_config).await;
+        let (base_url, shutdown_tx, relay_control) =
+            tenet::simulation::start_relay(relay_config).await;
         let mut inputs = tenet::simulation::build_simulation_inputs(&scenario_for_task.simulation);
         inputs.timing.base_real_time_per_step = Duration::from_millis(REAL_TIME_STEP_DELAY_MS);
         let mut harness = tenet::simulation::SimulationHarness::new(
@@ -118,6 +119,7 @@ async fn run_with_tui(
             inputs.timing,
             inputs.cohort_online_rates,
             Some(simulation_log_sink),
+            Some(relay_control),
         );
         let metrics = harness
             .run_with_progress_and_controls(

--- a/tests/relay_tests.rs
+++ b/tests/relay_tests.rs
@@ -96,6 +96,7 @@ async fn relay_expires_messages_after_ttl() {
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
+        pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     })
     .await;
 
@@ -149,6 +150,7 @@ async fn relay_deduplicates_by_message_id() {
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
+        pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     })
     .await;
 
@@ -203,6 +205,7 @@ async fn node_can_send_and_receive_through_relay() {
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
+        pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     })
     .await;
 

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -22,8 +22,9 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
+        pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
-    let (base_url, shutdown_tx) = start_relay(relay_config.clone()).await;
+    let (base_url, shutdown_tx, _relay_control) = start_relay(relay_config.clone()).await;
 
     let config = SimulationConfig {
         node_ids: vec![
@@ -61,6 +62,7 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
         inputs.keypairs,
         inputs.timing,
         inputs.cohort_online_rates,
+        None,
         None,
     );
 
@@ -113,8 +115,9 @@ async fn simulation_harness_tracks_online_handshake_metrics() {
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
+        pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
-    let (base_url, shutdown_tx) = start_relay(relay_config.clone()).await;
+    let (base_url, shutdown_tx, _relay_control) = start_relay(relay_config.clone()).await;
 
     let nodes = vec![
         tenet::simulation::Node::new("node-a", vec![false, true]),
@@ -139,6 +142,7 @@ async fn simulation_harness_tracks_online_handshake_metrics() {
         },
         HashMap::new(),
         None,
+        None,
     );
 
     harness.run(2, Vec::new()).await;
@@ -161,8 +165,9 @@ async fn simulation_harness_delivers_missed_messages_after_handshake() {
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
+        pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
-    let (base_url, shutdown_tx) = start_relay(relay_config.clone()).await;
+    let (base_url, shutdown_tx, _relay_control) = start_relay(relay_config.clone()).await;
 
     let nodes = vec![
         tenet::simulation::Node::new("node-a", vec![false, true, true]),
@@ -186,6 +191,7 @@ async fn simulation_harness_delivers_missed_messages_after_handshake() {
             base_real_time_per_step: Duration::ZERO,
         },
         HashMap::new(),
+        None,
         None,
     );
 
@@ -224,8 +230,9 @@ async fn simulation_harness_applies_dynamic_updates() {
         peer_log_window: Duration::from_secs(60),
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
+        pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
-    let (base_url, shutdown_tx) = start_relay(relay_config.clone()).await;
+    let (base_url, shutdown_tx, _relay_control) = start_relay(relay_config.clone()).await;
 
     let nodes = vec![
         Node::new("node-a", vec![true; 4]),
@@ -249,6 +256,7 @@ async fn simulation_harness_applies_dynamic_updates() {
             base_real_time_per_step: Duration::ZERO,
         },
         HashMap::new(),
+        None,
         None,
     );
 


### PR DESCRIPTION
### Motivation

- Reduce log spam from per-neighbor online announce entries by collapsing them into a single message listing all neighbors. 
- Prevent the relay from continuing to emit log lines while the simulation is paused which made the UI report peers as offline when paused.

### Description

- Add a `pause_flag: Arc<AtomicBool>` to `RelayConfig` and a `RelayControl` wrapper with `set_paused` to control the flag. 
- Make `log_message` respect the `pause_flag` and return early when the relay is paused to suppress relay output. 
- Collapse online announce logging in `SimulationHarness::enqueue_online_broadcasts` to a single call: `"{node_id} announced online to <neighbor list>"` instead of per-neighbor messages. 
- Wire the relay pause control through the runner: `start_relay` now returns a `RelayControl`, the TUI/CLI passes it into `SimulationHarness`, and the harness toggles the flag on `SimulationControlCommand::SetPaused`; update `RelayConfigToml::into_relay_config`, the relay binary, and tests accordingly.

### Testing

- Formatted the tree with `cargo fmt`. 
- Built the project with `cargo build` (succeeded). 
- Ran the full test suite with `cargo test` and all tests passed (`unit` and integration tests including relay and simulation harness tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ae8f26f94832584d6b4cd95f83f06)