### PR TITLE
Fix simulation metrics report serialization

### DIFF
--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -251,6 +251,13 @@ pub struct SenderRecipient {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct SenderRecipientCount {
+    pub sender: String,
+    pub recipient: String,
+    pub count: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct LatencyHistogram {
     pub counts: HashMap<usize, usize>,
     pub min: Option<usize>,
@@ -261,7 +268,7 @@ pub struct LatencyHistogram {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SimulationMetricsReport {
-    pub per_sender_recipient_counts: HashMap<SenderRecipient, usize>,
+    pub per_sender_recipient_counts: Vec<SenderRecipientCount>,
     pub first_delivery_latency: LatencyHistogram,
     pub all_recipients_delivery_latency: LatencyHistogram,
     pub first_delivery_latency_seconds: LatencyHistogram,
@@ -1771,8 +1778,22 @@ impl MetricsTracker {
     }
 
     fn report(&self, aggregate_metrics: SimulationAggregateMetrics) -> SimulationMetricsReport {
+        let mut per_sender_recipient_counts: Vec<SenderRecipientCount> = self
+            .per_sender_recipient_counts
+            .iter()
+            .map(|(key, count)| SenderRecipientCount {
+                sender: key.sender.clone(),
+                recipient: key.recipient.clone(),
+                count: *count,
+            })
+            .collect();
+        per_sender_recipient_counts.sort_by(|left, right| {
+            left.sender
+                .cmp(&right.sender)
+                .then_with(|| left.recipient.cmp(&right.recipient))
+        });
         SimulationMetricsReport {
-            per_sender_recipient_counts: self.per_sender_recipient_counts.clone(),
+            per_sender_recipient_counts,
             first_delivery_latency: self.first_delivery_latency.report(),
             all_recipients_delivery_latency: self.all_recipients_delivery_latency.report(),
             first_delivery_latency_seconds: self.first_delivery_latency_seconds.report(),


### PR DESCRIPTION
### Motivation
- The simulation report included a `HashMap<SenderRecipient, usize>` which serializes to JSON with a non-string key and caused runtime errors like `"key must be a string"` when exporting from the TUI.
- Reports should be stable and deterministic for consumers, so per-sender/recipient metrics need a stable, serializable representation.

### Description
- Added a new `SenderRecipientCount` struct with `sender`, `recipient`, and `count` fields and `Serialize` derived to provide a JSON-safe representation.
- Replaced the `per_sender_recipient_counts` field in `SimulationMetricsReport` from `HashMap<SenderRecipient, usize>` to `Vec<SenderRecipientCount>`.
- Converted the internal `per_sender_recipient_counts` map to a `Vec<SenderRecipientCount>` inside `MetricsTracker::report` and sorted the vector by `sender` then `recipient` for deterministic output.

### Testing
- Ran `cargo fmt` which completed successfully.
- Ran `cargo build` which completed successfully (with compiler warnings about unused fields but no errors).
- Ran `cargo test` and all automated tests passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ae74d42cc83259106a39e5829389d)