### PR TITLE
Refactor simulation harness to use client interface

### DIFF
--- a/src/bin/simulation.rs
+++ b/src/bin/simulation.rs
@@ -110,7 +110,7 @@ async fn run_with_tui(
         inputs.timing.base_real_time_per_step = Duration::from_millis(REAL_TIME_STEP_DELAY_MS);
         let mut harness = tenet::simulation::SimulationHarness::new(
             base_url,
-            inputs.nodes,
+            inputs.clients,
             inputs.direct_links,
             scenario_for_task.direct_enabled.unwrap_or(true),
             scenario_for_task.relay.ttl_seconds,
@@ -638,9 +638,9 @@ fn handle_key_event(
                     trimmed.to_string()
                 };
                 let schedule = vec![true; total_steps];
-                let node = tenet::simulation::Node::new(&node_id, schedule);
+                let client = tenet::simulation::SimulationClient::new(&node_id, schedule);
                 let keypair = generate_keypair();
-                let _ = control_tx.send(SimulationControlCommand::AddPeer { node, keypair });
+                let _ = control_tx.send(SimulationControlCommand::AddPeer { client, keypair });
                 *input_mode = InputMode::Normal;
                 *status_message = format!("Added peer request queued for {node_id}.");
             }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 use std::collections::{HashMap, HashSet};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use axum::Router;
 use rand::distributions::Uniform;
@@ -12,11 +12,14 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::crypto::{generate_keypair_with_rng, StoredKeypair, CONTENT_KEY_SIZE, NONCE_SIZE};
 use crate::protocol::{
-    build_encrypted_payload, build_envelope_from_payload, build_meta_payload,
-    build_plaintext_payload, decrypt_encrypted_payload, ContentId, Envelope, MessageKind,
-    MetaMessage, Payload,
+    build_encrypted_payload, build_plaintext_payload, ContentId, Envelope, MessageKind, Payload,
 };
 use crate::relay::{app, RelayConfig, RelayControl, RelayState};
+
+mod client;
+
+pub use client::SimulationClient;
+use client::{Client, ClientContext};
 
 const SIMULATION_PAYLOAD_AAD: &[u8] = b"tenet-simulation";
 const SIMULATION_HPKE_INFO: &[u8] = b"tenet-simulation-hpke";
@@ -397,45 +400,9 @@ pub struct SimMessage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct StoreForPayload {
-    envelope: Envelope,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlannedSend {
     pub step: usize,
     pub message: SimMessage,
-}
-
-#[derive(Debug, Clone)]
-pub struct Node {
-    id: String,
-    schedule: Vec<bool>,
-    inbox: Vec<SimMessage>,
-    seen: HashSet<String>,
-}
-
-impl Node {
-    pub fn new(id: &str, schedule: Vec<bool>) -> Self {
-        Self {
-            id: id.to_string(),
-            schedule,
-            inbox: Vec::new(),
-            seen: HashSet::new(),
-        }
-    }
-
-    fn online_at(&self, step: usize) -> bool {
-        self.schedule.get(step).copied().unwrap_or(false)
-    }
-
-    fn receive(&mut self, message: SimMessage) -> bool {
-        if self.seen.insert(message.id.clone()) {
-            self.inbox.push(message);
-            return true;
-        }
-        false
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -444,23 +411,9 @@ struct HistoricalMessage {
     envelope: Envelope,
 }
 
-#[derive(Debug, Clone)]
-struct StoredForPeerMessage {
-    store_for_id: String,
-    envelope: Envelope,
-}
-
-#[derive(Debug, Clone)]
-struct PendingOnlineBroadcast {
-    sender_id: String,
-    recipient_id: String,
-    sent_step: usize,
-    expires_at: usize,
-}
-
 #[derive(Debug)]
 pub struct SimulationInputs {
-    pub nodes: Vec<Node>,
+    pub clients: Vec<SimulationClient>,
     pub planned_sends: Vec<PlannedSend>,
     pub direct_links: HashSet<(String, String)>,
     pub keypairs: HashMap<String, StoredKeypair>,
@@ -471,33 +424,37 @@ pub struct SimulationInputs {
 
 #[derive(Debug, Clone)]
 pub enum SimulationControlCommand {
-    AddPeer { node: Node, keypair: StoredKeypair },
-    AddFriendship { peer_a: String, peer_b: String },
-    AdjustSpeedFactor { delta: f64 },
-    SetSpeedFactor { speed_factor: f64 },
-    SetPaused { paused: bool },
+    AddPeer {
+        client: SimulationClient,
+        keypair: StoredKeypair,
+    },
+    AddFriendship {
+        peer_a: String,
+        peer_b: String,
+    },
+    AdjustSpeedFactor {
+        delta: f64,
+    },
+    SetSpeedFactor {
+        speed_factor: f64,
+    },
+    SetPaused {
+        paused: bool,
+    },
     Stop,
-}
-
-enum IncomingEnvelopeAction {
-    DirectMessage(SimMessage),
-    StoredForPeer(StoredForPeerMessage),
 }
 
 pub struct SimulationHarness {
     relay_base_url: String,
-    nodes: HashMap<String, Node>,
+    clients: HashMap<String, Box<dyn Client>>,
     direct_links: HashSet<(String, String)>,
     neighbors: HashMap<String, Vec<String>>,
     direct_enabled: bool,
     ttl_seconds: u64,
     encryption: MessageEncryption,
     keypairs: HashMap<String, StoredKeypair>,
-    last_seen_by_peer: HashMap<String, HashMap<String, u64>>,
     message_history: HashMap<(String, String), Vec<HistoricalMessage>>,
     message_send_steps: HashMap<String, usize>,
-    pending_online_broadcasts: Vec<PendingOnlineBroadcast>,
-    stored_forwards: HashMap<String, Vec<StoredForPeerMessage>>,
     pending_forwarded_messages: HashSet<String>,
     metrics: SimulationMetrics,
     metrics_tracker: MetricsTracker,
@@ -509,7 +466,7 @@ pub struct SimulationHarness {
 impl SimulationHarness {
     pub fn new(
         relay_base_url: String,
-        nodes: Vec<Node>,
+        clients: Vec<SimulationClient>,
         direct_links: HashSet<(String, String)>,
         direct_enabled: bool,
         ttl_seconds: u64,
@@ -528,15 +485,11 @@ impl SimulationHarness {
                 .or_default()
                 .push(recipient.clone());
         }
-        let mut last_seen_by_peer = HashMap::new();
-        for node in &nodes {
-            last_seen_by_peer.insert(node.id.clone(), HashMap::new());
-        }
         Self {
             relay_base_url,
-            nodes: nodes
+            clients: clients
                 .into_iter()
-                .map(|node| (node.id.clone(), node))
+                .map(|client| (client.id().to_string(), Box::new(client) as Box<dyn Client>))
                 .collect(),
             direct_links,
             neighbors,
@@ -544,11 +497,8 @@ impl SimulationHarness {
             ttl_seconds,
             encryption,
             keypairs,
-            last_seen_by_peer,
             message_history: HashMap::new(),
             message_send_steps: HashMap::new(),
-            pending_online_broadcasts: Vec::new(),
-            stored_forwards: HashMap::new(),
             pending_forwarded_messages: HashSet::new(),
             metrics: SimulationMetrics {
                 planned_messages,
@@ -579,18 +529,18 @@ impl SimulationHarness {
     }
 
     fn aggregate_metrics(&self) -> SimulationAggregateMetrics {
-        let peer_ids: Vec<String> = self.nodes.keys().cloned().collect();
+        let peer_ids: Vec<String> = self.clients.keys().cloned().collect();
         let peer_feed_messages = CountSummary::from_counts(peer_ids.iter().map(|peer_id| {
-            self.nodes
+            self.clients
                 .get(peer_id)
-                .map(|node| node.inbox.len())
+                .map(|client| client.inbox().len())
                 .unwrap_or(0)
         }));
         let stored_unforwarded_by_peer =
             CountSummary::from_counts(peer_ids.iter().map(|peer_id| {
-                self.stored_forwards
+                self.clients
                     .get(peer_id)
-                    .map(|stored| stored.len())
+                    .map(|client| client.stored_forward_count())
                     .unwrap_or(0)
             }));
         let sent_messages_by_kind = self.metrics_tracker.sent_message_summary_by_kind(&peer_ids);
@@ -606,7 +556,7 @@ impl SimulationHarness {
     }
 
     pub fn total_nodes(&self) -> usize {
-        self.nodes.len()
+        self.clients.len()
     }
 
     pub fn speed_factor(&self) -> f64 {
@@ -632,21 +582,20 @@ impl SimulationHarness {
         previous_online: &mut HashMap<String, bool>,
     ) {
         match command {
-            SimulationControlCommand::AddPeer { node, keypair } => {
-                let node_id = node.id.clone();
-                if self.nodes.contains_key(&node_id) {
+            SimulationControlCommand::AddPeer { client, keypair } => {
+                let client_id = client.id().to_string();
+                if self.clients.contains_key(&client_id) {
                     return;
                 }
-                self.nodes.insert(node_id.clone(), node);
-                self.keypairs.insert(node_id.clone(), keypair);
-                self.last_seen_by_peer
-                    .insert(node_id.clone(), HashMap::new());
-                self.neighbors.entry(node_id.clone()).or_default();
-                previous_online.entry(node_id.clone()).or_insert(false);
-                self.log_action(step, format!("{node_id} added"));
+                self.clients
+                    .insert(client_id.clone(), Box::new(client) as Box<dyn Client>);
+                self.keypairs.insert(client_id.clone(), keypair);
+                self.neighbors.entry(client_id.clone()).or_default();
+                previous_online.entry(client_id.clone()).or_insert(false);
+                self.log_action(step, format!("{client_id} added"));
             }
             SimulationControlCommand::AddFriendship { peer_a, peer_b } => {
-                if !(self.nodes.contains_key(&peer_a) && self.nodes.contains_key(&peer_b)) {
+                if !(self.clients.contains_key(&peer_a) && self.clients.contains_key(&peer_b)) {
                     return;
                 }
                 if self.direct_links.insert((peer_a.clone(), peer_b.clone())) {
@@ -685,292 +634,6 @@ impl SimulationHarness {
         }
     }
 
-    fn record_message_send(&mut self, message: &SimMessage, step: usize, envelope: &Envelope) {
-        self.message_send_steps.insert(message.id.clone(), step);
-        self.message_history
-            .entry((message.sender.clone(), message.recipient.clone()))
-            .or_default()
-            .push(HistoricalMessage {
-                send_step: step,
-                envelope: envelope.clone(),
-            });
-    }
-
-    fn update_last_seen(&mut self, recipient_id: &str, sender_id: &str, message_id: &str) {
-        let Some(send_step) = self.message_send_steps.get(message_id) else {
-            return;
-        };
-        let entry = self
-            .last_seen_by_peer
-            .entry(recipient_id.to_string())
-            .or_default()
-            .entry(sender_id.to_string())
-            .or_insert(0);
-        *entry = (*entry).max(*send_step as u64);
-    }
-
-    fn last_seen_for(&self, recipient_id: &str, sender_id: &str) -> u64 {
-        self.last_seen_by_peer
-            .get(recipient_id)
-            .and_then(|map| map.get(sender_id))
-            .copied()
-            .unwrap_or(0)
-    }
-
-    async fn enqueue_online_broadcasts(&mut self, node_id: &str, step: usize) {
-        let Some(neighbors) = self.neighbors.get(node_id) else {
-            return;
-        };
-        let neighbors = neighbors.clone();
-        if neighbors.is_empty() {
-            return;
-        }
-        self.log_action(
-            step + 1,
-            format!("{node_id} announced online to {}", neighbors.join(", ")),
-        );
-        for neighbor in neighbors {
-            let meta = MetaMessage::Online {
-                peer_id: node_id.to_string(),
-                timestamp: step as u64,
-            };
-            self.send_meta_message(node_id, &neighbor, step, &meta)
-                .await;
-            self.pending_online_broadcasts.push(PendingOnlineBroadcast {
-                sender_id: node_id.to_string(),
-                recipient_id: neighbor.clone(),
-                sent_step: step,
-                expires_at: step.saturating_add(SIMULATION_ACK_WINDOW_STEPS),
-            });
-            self.metrics_tracker.record_online_broadcast();
-        }
-    }
-
-    async fn process_pending_online_broadcasts(
-        &mut self,
-        step: usize,
-        online_nodes: &HashSet<String>,
-    ) -> usize {
-        let pending = std::mem::take(&mut self.pending_online_broadcasts);
-        let mut remaining = Vec::with_capacity(pending.len());
-        let mut delivered: usize = 0;
-        for pending in pending {
-            if step > pending.expires_at {
-                continue;
-            }
-            if online_nodes.contains(&pending.recipient_id) {
-                let ack = MetaMessage::Ack {
-                    peer_id: pending.recipient_id.clone(),
-                    online_timestamp: pending.sent_step as u64,
-                };
-                self.send_meta_message(&pending.recipient_id, &pending.sender_id, step, &ack)
-                    .await;
-                self.metrics_tracker.record_ack();
-                self.log_action(
-                    step + 1,
-                    format!(
-                        "{} acknowledged {} online",
-                        pending.recipient_id, pending.sender_id
-                    ),
-                );
-                delivered = delivered.saturating_add(
-                    self.handle_message_request(&pending.sender_id, &pending.recipient_id, step)
-                        .await,
-                );
-                continue;
-            }
-            remaining.push(pending);
-        }
-        self.pending_online_broadcasts = remaining;
-        delivered
-    }
-
-    async fn handle_message_request(
-        &mut self,
-        requester: &str,
-        responder: &str,
-        step: usize,
-    ) -> usize {
-        let last_seen = self.last_seen_for(requester, responder);
-        let request = MetaMessage::MessageRequest {
-            peer_id: responder.to_string(),
-            since_timestamp: last_seen,
-        };
-        self.send_meta_message(requester, responder, step, &request)
-            .await;
-        self.metrics_tracker.record_missed_message_request();
-        self.log_action(
-            step + 1,
-            format!("{requester} requested missed messages from {responder}"),
-        );
-        let Some(history) = self
-            .message_history
-            .get(&(responder.to_string(), requester.to_string()))
-        else {
-            return 0;
-        };
-        let entries: Vec<HistoricalMessage> = history
-            .iter()
-            .filter(|entry| entry.send_step as u64 >= last_seen)
-            .cloned()
-            .collect();
-        let mut delivered = 0;
-        for entry in entries {
-            if self.deliver_missed_message(&entry.envelope, requester, step) {
-                delivered += 1;
-            }
-        }
-        if delivered > 0 {
-            self.log_action(
-                step + 1,
-                format!("{responder} delivered {delivered} missed messages to {requester}"),
-            );
-        }
-        delivered
-    }
-
-    async fn send_meta_message(
-        &mut self,
-        sender_id: &str,
-        recipient_id: &str,
-        step: usize,
-        meta: &MetaMessage,
-    ) {
-        let Ok(payload) = build_meta_payload(meta) else {
-            return;
-        };
-        let Ok(envelope) = build_envelope_from_payload(
-            sender_id.to_string(),
-            recipient_id.to_string(),
-            None,
-            None,
-            step as u64,
-            self.ttl_seconds,
-            MessageKind::Meta,
-            None,
-            payload,
-        ) else {
-            return;
-        };
-        self.metrics_tracker
-            .record_meta_send(sender_id.to_string(), &envelope);
-        let _ = post_envelope(&self.relay_base_url, &envelope).await;
-    }
-
-    fn deliver_missed_message(
-        &mut self,
-        envelope: &Envelope,
-        recipient_id: &str,
-        step: usize,
-    ) -> bool {
-        let message_id = envelope.header.message_id.0.clone();
-        let message = self.decode_direct_envelope(envelope, &message_id, recipient_id);
-        let Some(message) = message else {
-            return false;
-        };
-        let Some(node) = self.nodes.get_mut(recipient_id) else {
-            return false;
-        };
-        if node.receive(message.clone()) {
-            self.metrics_tracker.record_missed_message_delivery();
-            self.record_delivery_metrics(&message, recipient_id, step);
-            self.log_action(
-                step + 1,
-                format!("{recipient_id} received missed message {}", message.id),
-            );
-            return true;
-        }
-        false
-    }
-
-    fn record_delivery_metrics(
-        &mut self,
-        message: &SimMessage,
-        recipient_id: &str,
-        step: usize,
-    ) -> Option<usize> {
-        if self.pending_forwarded_messages.remove(&message.id) {
-            self.metrics.store_forwards_delivered =
-                self.metrics.store_forwards_delivered.saturating_add(1);
-            self.metrics_tracker.record_store_forward_delivery();
-        }
-        let latency = self
-            .metrics_tracker
-            .record_delivery(&message.id, recipient_id, step);
-        self.update_last_seen(recipient_id, &message.sender, &message.id);
-        latency
-    }
-
-    fn store_forward_message(
-        &mut self,
-        storage_peer_id: &str,
-        step: usize,
-        message: StoredForPeerMessage,
-    ) {
-        self.stored_forwards
-            .entry(storage_peer_id.to_string())
-            .or_default()
-            .push(message);
-        self.metrics.store_forwards_stored = self.metrics.store_forwards_stored.saturating_add(1);
-        self.metrics_tracker.record_store_forward_stored();
-        self.log_action(
-            step + 1,
-            format!("{storage_peer_id} stored a store-forward message"),
-        );
-    }
-
-    fn select_storage_peer(&self, sender: &str, recipient: &str) -> Option<String> {
-        let sender_neighbors = self.neighbors.get(sender)?;
-        let recipient_neighbors = self.neighbors.get(recipient)?;
-        let sender_set: HashSet<&String> = sender_neighbors.iter().collect();
-        let mut mutual: Vec<String> = recipient_neighbors
-            .iter()
-            .filter(|candidate| sender_set.contains(candidate))
-            .cloned()
-            .collect();
-        mutual.sort();
-        mutual
-            .into_iter()
-            .find(|candidate| candidate != sender && candidate != recipient)
-    }
-
-    async fn forward_store_forwards(&mut self, step: usize, online_set: &HashSet<String>) -> usize {
-        let mut forwarded = 0usize;
-        let mut log_entries = Vec::new();
-        let storage_peers: Vec<String> = self.stored_forwards.keys().cloned().collect();
-        for storage_peer_id in storage_peers {
-            if !online_set.contains(&storage_peer_id) {
-                continue;
-            }
-            if let Some(stored) = self.stored_forwards.get_mut(&storage_peer_id) {
-                let mut remaining = Vec::with_capacity(stored.len());
-                for entry in stored.drain(..) {
-                    if online_set.contains(&entry.store_for_id) {
-                        let message_id = entry.envelope.header.message_id.0.clone();
-                        let _ = post_envelope(&self.relay_base_url, &entry.envelope).await;
-                        self.pending_forwarded_messages.insert(message_id);
-                        self.metrics.store_forwards_forwarded =
-                            self.metrics.store_forwards_forwarded.saturating_add(1);
-                        self.metrics_tracker
-                            .record_store_forward_forwarded(&storage_peer_id);
-                        log_entries.push(format!(
-                            "{storage_peer_id} forwarded stored message to {}",
-                            entry.store_for_id
-                        ));
-                        forwarded = forwarded.saturating_add(1);
-                    } else {
-                        remaining.push(entry);
-                    }
-                }
-                *stored = remaining;
-            }
-        }
-        for entry in log_entries {
-            self.log_action(step + 1, entry);
-        }
-        forwarded
-    }
-
     pub async fn run(&mut self, steps: usize, plan: Vec<PlannedSend>) -> SimulationMetrics {
         self.metrics.planned_messages = plan.len();
         let mut sends_by_step: HashMap<usize, Vec<SimMessage>> = HashMap::new();
@@ -982,32 +645,95 @@ impl SimulationHarness {
         }
 
         let mut previous_online: HashMap<String, bool> =
-            self.nodes.keys().map(|id| (id.clone(), false)).collect();
+            self.clients.keys().map(|id| (id.clone(), false)).collect();
+        let direct_enabled = self.direct_enabled;
+        let ttl_seconds = self.ttl_seconds;
+        let encryption = self.encryption.clone();
+        let direct_links = &self.direct_links;
+        let neighbors = &self.neighbors;
+        let keypairs = &self.keypairs;
+        let relay_base_url = self.relay_base_url.clone();
+        let log_sink = self.log_sink.clone();
+        let (
+            clients,
+            message_history,
+            message_send_steps,
+            pending_forwarded_messages,
+            metrics,
+            metrics_tracker,
+        ) = (
+            &mut self.clients,
+            &mut self.message_history,
+            &mut self.message_send_steps,
+            &mut self.pending_forwarded_messages,
+            &mut self.metrics,
+            &mut self.metrics_tracker,
+        );
 
         for step in 0..steps {
-            if let Some(messages) = sends_by_step.get(&step) {
-                for message in messages {
-                    if self
-                        .nodes
-                        .get(&message.sender)
-                        .is_some_and(|node| node.online_at(step))
-                    {
-                        self.metrics.sent_messages += 1;
-                        let delivered_direct = self.route_message(step, message).await;
-                        if delivered_direct.is_some() {
-                            self.metrics.direct_deliveries += 1;
-                        }
-                    }
-                }
-            }
-
-            let online_ids: Vec<String> = self
-                .nodes
+            let online_ids: Vec<String> = clients
                 .iter()
-                .filter(|(_, node)| node.online_at(step))
+                .filter(|(_, client)| client.is_online(step))
                 .map(|(id, _)| id.clone())
                 .collect();
             let online_set: HashSet<String> = online_ids.iter().cloned().collect();
+            let mut pending_direct_deliveries = Vec::new();
+            let mut outbound_envelopes = Vec::new();
+            if let Some(messages) = sends_by_step.get(&step) {
+                for message in messages {
+                    if !online_set.contains(&message.sender) {
+                        continue;
+                    }
+                    metrics.sent_messages = metrics.sent_messages.saturating_add(1);
+                    if let Some(client) = clients.get_mut(&message.sender) {
+                        let mut context = ClientContext {
+                            direct_enabled,
+                            ttl_seconds,
+                            encryption: encryption.clone(),
+                            direct_links,
+                            neighbors,
+                            keypairs,
+                            message_history: &mut *message_history,
+                            message_send_steps: &mut *message_send_steps,
+                            pending_forwarded_messages: &mut *pending_forwarded_messages,
+                            metrics: &mut *metrics,
+                            metrics_tracker: &mut *metrics_tracker,
+                            log_sink: &log_sink,
+                        };
+                        let outcome = client.enqueue_sends(
+                            step,
+                            std::slice::from_ref(message),
+                            &online_set,
+                            &mut context,
+                        );
+                        outbound_envelopes.extend(outcome.envelopes);
+                        pending_direct_deliveries.extend(outcome.direct_deliveries);
+                    }
+                }
+            }
+            for envelope in outbound_envelopes {
+                let _ = post_envelope(&relay_base_url, &envelope).await;
+            }
+            for message in pending_direct_deliveries {
+                if let Some(client) = clients.get_mut(&message.recipient) {
+                    let mut context = ClientContext {
+                        direct_enabled,
+                        ttl_seconds,
+                        encryption: encryption.clone(),
+                        direct_links,
+                        neighbors,
+                        keypairs,
+                        message_history: &mut *message_history,
+                        message_send_steps: &mut *message_send_steps,
+                        pending_forwarded_messages: &mut *pending_forwarded_messages,
+                        metrics: &mut *metrics,
+                        metrics_tracker: &mut *metrics_tracker,
+                        log_sink: &log_sink,
+                    };
+                    let _ = client.handle_direct_delivery(step, message, &mut context, None);
+                }
+            }
+
             let newly_online: Vec<String> = online_ids
                 .iter()
                 .filter(|id| !previous_online.get(*id).copied().unwrap_or(false))
@@ -1020,66 +746,136 @@ impl SimulationHarness {
                 .collect();
 
             for node_id in &newly_online {
-                self.log_action(step + 1, format!("{node_id} came online"));
+                if let Some(log_sink) = &log_sink {
+                    log_sink(format!("[sim step={}] {} came online", step + 1, node_id));
+                }
             }
             for node_id in &offline {
-                self.log_action(step + 1, format!("{node_id} went offline"));
-            }
-
-            let _ = self.forward_store_forwards(step, &online_set).await;
-
-            for node_id in &newly_online {
-                let envelopes = fetch_inbox(&self.relay_base_url, node_id)
-                    .await
-                    .unwrap_or_default();
-                for envelope in envelopes {
-                    match self.decode_envelope_action(&envelope, node_id) {
-                        Some(IncomingEnvelopeAction::DirectMessage(message)) => {
-                            if let Some(node) = self.nodes.get_mut(node_id) {
-                                if node.receive(message.clone()) {
-                                    self.metrics.inbox_deliveries += 1;
-                                    self.record_delivery_metrics(&message, node_id, step);
-                                }
-                            }
-                        }
-                        Some(IncomingEnvelopeAction::StoredForPeer(message)) => {
-                            self.store_forward_message(node_id, step, message);
-                        }
-                        None => {}
-                    }
+                if let Some(log_sink) = &log_sink {
+                    log_sink(format!("[sim step={}] {} went offline", step + 1, node_id));
                 }
             }
 
-            for node_id in &newly_online {
-                self.enqueue_online_broadcasts(node_id, step).await;
+            let mut forward_envelopes = Vec::new();
+            for client in clients.values_mut() {
+                let mut context = ClientContext {
+                    direct_enabled,
+                    ttl_seconds,
+                    encryption: encryption.clone(),
+                    direct_links,
+                    neighbors,
+                    keypairs,
+                    message_history: &mut *message_history,
+                    message_send_steps: &mut *message_send_steps,
+                    pending_forwarded_messages: &mut *pending_forwarded_messages,
+                    metrics: &mut *metrics,
+                    metrics_tracker: &mut *metrics_tracker,
+                    log_sink: &log_sink,
+                };
+                forward_envelopes.extend(client.forward_store_forwards(
+                    step,
+                    &online_set,
+                    &mut context,
+                ));
+            }
+            for envelope in forward_envelopes {
+                let _ = post_envelope(&relay_base_url, &envelope).await;
             }
 
-            let _ = self
-                .process_pending_online_broadcasts(step, &online_set)
-                .await;
+            for node_id in &newly_online {
+                let envelopes = fetch_inbox(&relay_base_url, node_id)
+                    .await
+                    .unwrap_or_default();
+                if let Some(client) = clients.get_mut(node_id) {
+                    let mut context = ClientContext {
+                        direct_enabled,
+                        ttl_seconds,
+                        encryption: encryption.clone(),
+                        direct_links,
+                        neighbors,
+                        keypairs,
+                        message_history: &mut *message_history,
+                        message_send_steps: &mut *message_send_steps,
+                        pending_forwarded_messages: &mut *pending_forwarded_messages,
+                        metrics: &mut *metrics,
+                        metrics_tracker: &mut *metrics_tracker,
+                        log_sink: &log_sink,
+                    };
+                    client.handle_inbox(step, envelopes, &mut context, None);
+                }
+            }
+
+            let mut online_envelopes = Vec::new();
+            for node_id in &newly_online {
+                if let Some(client) = clients.get_mut(node_id) {
+                    let mut context = ClientContext {
+                        direct_enabled,
+                        ttl_seconds,
+                        encryption: encryption.clone(),
+                        direct_links,
+                        neighbors,
+                        keypairs,
+                        message_history: &mut *message_history,
+                        message_send_steps: &mut *message_send_steps,
+                        pending_forwarded_messages: &mut *pending_forwarded_messages,
+                        metrics: &mut *metrics,
+                        metrics_tracker: &mut *metrics_tracker,
+                        log_sink: &log_sink,
+                    };
+                    online_envelopes.extend(client.announce_online(step, &mut context));
+                }
+            }
+            for envelope in online_envelopes {
+                let _ = post_envelope(&relay_base_url, &envelope).await;
+            }
+
+            let mut broadcast_envelopes = Vec::new();
+            for client in clients.values_mut() {
+                let mut context = ClientContext {
+                    direct_enabled,
+                    ttl_seconds,
+                    encryption: encryption.clone(),
+                    direct_links,
+                    neighbors,
+                    keypairs,
+                    message_history: &mut *message_history,
+                    message_send_steps: &mut *message_send_steps,
+                    pending_forwarded_messages: &mut *pending_forwarded_messages,
+                    metrics: &mut *metrics,
+                    metrics_tracker: &mut *metrics_tracker,
+                    log_sink: &log_sink,
+                };
+                let outcome =
+                    client.process_pending_online_broadcasts(step, &online_set, &mut context);
+                broadcast_envelopes.extend(outcome.envelopes);
+            }
+            for envelope in broadcast_envelopes {
+                let _ = post_envelope(&relay_base_url, &envelope).await;
+            }
 
             for node_id in &online_ids {
                 if newly_online.contains(node_id) {
                     continue;
                 }
-                let envelopes = fetch_inbox(&self.relay_base_url, node_id)
+                let envelopes = fetch_inbox(&relay_base_url, node_id)
                     .await
                     .unwrap_or_default();
-                for envelope in envelopes {
-                    match self.decode_envelope_action(&envelope, node_id) {
-                        Some(IncomingEnvelopeAction::DirectMessage(message)) => {
-                            if let Some(node) = self.nodes.get_mut(node_id) {
-                                if node.receive(message.clone()) {
-                                    self.metrics.inbox_deliveries += 1;
-                                    self.record_delivery_metrics(&message, node_id, step);
-                                }
-                            }
-                        }
-                        Some(IncomingEnvelopeAction::StoredForPeer(message)) => {
-                            self.store_forward_message(node_id, step, message);
-                        }
-                        None => {}
-                    }
+                if let Some(client) = clients.get_mut(node_id) {
+                    let mut context = ClientContext {
+                        direct_enabled,
+                        ttl_seconds,
+                        encryption: encryption.clone(),
+                        direct_links,
+                        neighbors,
+                        keypairs,
+                        message_history: &mut *message_history,
+                        message_send_steps: &mut *message_send_steps,
+                        pending_forwarded_messages: &mut *pending_forwarded_messages,
+                        metrics: &mut *metrics,
+                        metrics_tracker: &mut *metrics_tracker,
+                        log_sink: &log_sink,
+                    };
+                    client.handle_inbox(step, envelopes, &mut context, None);
                 }
             }
 
@@ -1093,7 +889,7 @@ impl SimulationHarness {
             }
         }
 
-        self.metrics()
+        metrics.clone()
     }
 
     pub async fn run_with_progress<F>(
@@ -1133,9 +929,14 @@ impl SimulationHarness {
 
         let mut rolling_latency = RollingLatencyTracker::new(100);
         let mut previous_online: HashMap<String, bool> =
-            self.nodes.keys().map(|id| (id.clone(), false)).collect();
+            self.clients.keys().map(|id| (id.clone(), false)).collect();
         let mut paused = false;
         let mut stop_requested = false;
+        let direct_enabled = self.direct_enabled;
+        let ttl_seconds = self.ttl_seconds;
+        let encryption = self.encryption.clone();
+        let relay_base_url = self.relay_base_url.clone();
+        let log_sink = self.log_sink.clone();
 
         let mut step = 0usize;
         while step < steps {
@@ -1167,138 +968,281 @@ impl SimulationHarness {
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 continue;
             }
-            let mut sent_messages = 0usize;
-            let mut received_messages = 0usize;
-            if let Some(messages) = sends_by_step.get(&step) {
-                for message in messages {
-                    if self
-                        .nodes
-                        .get(&message.sender)
-                        .is_some_and(|node| node.online_at(step))
-                    {
-                        sent_messages += 1;
-                        self.metrics.sent_messages += 1;
-                        if let Some(latency) = self.route_message(step, message).await {
-                            self.metrics.direct_deliveries += 1;
-                            received_messages += 1;
-                            rolling_latency.record(latency);
+            let (sent_messages, received_messages, online_nodes) = {
+                let direct_links = &self.direct_links;
+                let neighbors = &self.neighbors;
+                let keypairs = &self.keypairs;
+                let (
+                    clients,
+                    message_history,
+                    message_send_steps,
+                    pending_forwarded_messages,
+                    metrics,
+                    metrics_tracker,
+                ) = (
+                    &mut self.clients,
+                    &mut self.message_history,
+                    &mut self.message_send_steps,
+                    &mut self.pending_forwarded_messages,
+                    &mut self.metrics,
+                    &mut self.metrics_tracker,
+                );
+                let mut sent_messages = 0usize;
+                let mut received_messages = 0usize;
+                let online_ids: Vec<String> = clients
+                    .iter()
+                    .filter(|(_, client)| client.is_online(step))
+                    .map(|(id, _)| id.clone())
+                    .collect();
+                let online_set: HashSet<String> = online_ids.iter().cloned().collect();
+                let mut pending_direct_deliveries = Vec::new();
+                let mut outbound_envelopes = Vec::new();
+                if let Some(messages) = sends_by_step.get(&step) {
+                    for message in messages {
+                        if !online_set.contains(&message.sender) {
+                            continue;
+                        }
+                        sent_messages = sent_messages.saturating_add(1);
+                        metrics.sent_messages = metrics.sent_messages.saturating_add(1);
+                        if let Some(client) = clients.get_mut(&message.sender) {
+                            let mut context = ClientContext {
+                                direct_enabled,
+                                ttl_seconds,
+                                encryption: encryption.clone(),
+                                direct_links,
+                                neighbors,
+                                keypairs,
+                                message_history: &mut *message_history,
+                                message_send_steps: &mut *message_send_steps,
+                                pending_forwarded_messages: &mut *pending_forwarded_messages,
+                                metrics: &mut *metrics,
+                                metrics_tracker: &mut *metrics_tracker,
+                                log_sink: &log_sink,
+                            };
+                            let outcome = client.enqueue_sends(
+                                step,
+                                std::slice::from_ref(message),
+                                &online_set,
+                                &mut context,
+                            );
+                            outbound_envelopes.extend(outcome.envelopes);
+                            pending_direct_deliveries.extend(outcome.direct_deliveries);
                         }
                     }
                 }
-            }
-
-            let online_ids: Vec<String> = self
-                .nodes
-                .iter()
-                .filter(|(_, node)| node.online_at(step))
-                .map(|(id, _)| id.clone())
-                .collect();
-            let online_set: HashSet<String> = online_ids.iter().cloned().collect();
-            let newly_online: Vec<String> = online_ids
-                .iter()
-                .filter(|id| !previous_online.get(*id).copied().unwrap_or(false))
-                .cloned()
-                .collect();
-            let offline: Vec<String> = previous_online
-                .iter()
-                .filter(|(id, was_online)| **was_online && !online_set.contains(*id))
-                .map(|(id, _)| id.clone())
-                .collect();
-
-            for node_id in &newly_online {
-                self.log_action(step + 1, format!("{node_id} came online"));
-            }
-            for node_id in &offline {
-                self.log_action(step + 1, format!("{node_id} went offline"));
-            }
-
-            let _ = self.forward_store_forwards(step, &online_set).await;
-
-            for node_id in &newly_online {
-                let envelopes = fetch_inbox(&self.relay_base_url, node_id)
-                    .await
-                    .unwrap_or_default();
-                for envelope in envelopes {
-                    match self.decode_envelope_action(&envelope, node_id) {
-                        Some(IncomingEnvelopeAction::DirectMessage(message)) => {
-                            if let Some(node) = self.nodes.get_mut(node_id) {
-                                if node.receive(message.clone()) {
-                                    self.metrics.inbox_deliveries += 1;
-                                    if let Some(latency) =
-                                        self.record_delivery_metrics(&message, node_id, step)
-                                    {
-                                        rolling_latency.record(latency);
-                                    }
-                                    received_messages += 1;
-                                }
-                            }
+                for envelope in outbound_envelopes {
+                    let _ = post_envelope(&relay_base_url, &envelope).await;
+                }
+                for message in pending_direct_deliveries {
+                    if let Some(client) = clients.get_mut(&message.recipient) {
+                        let mut context = ClientContext {
+                            direct_enabled,
+                            ttl_seconds,
+                            encryption: encryption.clone(),
+                            direct_links,
+                            neighbors,
+                            keypairs,
+                            message_history: &mut *message_history,
+                            message_send_steps: &mut *message_send_steps,
+                            pending_forwarded_messages: &mut *pending_forwarded_messages,
+                            metrics: &mut *metrics,
+                            metrics_tracker: &mut *metrics_tracker,
+                            log_sink: &log_sink,
+                        };
+                        if client
+                            .handle_direct_delivery(
+                                step,
+                                message,
+                                &mut context,
+                                Some(&mut rolling_latency),
+                            )
+                            .is_some()
+                        {
+                            received_messages = received_messages.saturating_add(1);
                         }
-                        Some(IncomingEnvelopeAction::StoredForPeer(message)) => {
-                            self.store_forward_message(node_id, step, message);
-                        }
-                        None => {}
                     }
                 }
-            }
+                let newly_online: Vec<String> = online_ids
+                    .iter()
+                    .filter(|id| !previous_online.get(*id).copied().unwrap_or(false))
+                    .cloned()
+                    .collect();
+                let offline: Vec<String> = previous_online
+                    .iter()
+                    .filter(|(id, was_online)| **was_online && !online_set.contains(*id))
+                    .map(|(id, _)| id.clone())
+                    .collect();
 
-            for node_id in &newly_online {
-                self.enqueue_online_broadcasts(node_id, step).await;
-            }
-
-            let missed_deliveries = self
-                .process_pending_online_broadcasts(step, &online_set)
-                .await;
-            received_messages = received_messages.saturating_add(missed_deliveries);
-
-            for node_id in &online_ids {
-                if newly_online.contains(node_id) {
-                    continue;
-                }
-                let envelopes = fetch_inbox(&self.relay_base_url, node_id)
-                    .await
-                    .unwrap_or_default();
-                for envelope in envelopes {
-                    match self.decode_envelope_action(&envelope, node_id) {
-                        Some(IncomingEnvelopeAction::DirectMessage(message)) => {
-                            if let Some(node) = self.nodes.get_mut(node_id) {
-                                if node.receive(message.clone()) {
-                                    self.metrics.inbox_deliveries += 1;
-                                    if let Some(latency) =
-                                        self.record_delivery_metrics(&message, node_id, step)
-                                    {
-                                        rolling_latency.record(latency);
-                                    }
-                                    received_messages += 1;
-                                }
-                            }
-                        }
-                        Some(IncomingEnvelopeAction::StoredForPeer(message)) => {
-                            self.store_forward_message(node_id, step, message);
-                        }
-                        None => {}
+                for node_id in &newly_online {
+                    if let Some(log_sink) = &log_sink {
+                        log_sink(format!("[sim step={}] {} came online", step + 1, node_id));
                     }
                 }
-            }
-
-            for node_id in &online_ids {
-                previous_online.insert(node_id.clone(), true);
-            }
-            for (node_id, was_online) in previous_online.iter_mut() {
-                if !online_set.contains(node_id) {
-                    *was_online = false;
+                for node_id in &offline {
+                    if let Some(log_sink) = &log_sink {
+                        log_sink(format!("[sim step={}] {} went offline", step + 1, node_id));
+                    }
                 }
-            }
 
+                let mut forward_envelopes = Vec::new();
+                for client in clients.values_mut() {
+                    let mut context = ClientContext {
+                        direct_enabled,
+                        ttl_seconds,
+                        encryption: encryption.clone(),
+                        direct_links,
+                        neighbors,
+                        keypairs,
+                        message_history: &mut *message_history,
+                        message_send_steps: &mut *message_send_steps,
+                        pending_forwarded_messages: &mut *pending_forwarded_messages,
+                        metrics: &mut *metrics,
+                        metrics_tracker: &mut *metrics_tracker,
+                        log_sink: &log_sink,
+                    };
+                    forward_envelopes.extend(client.forward_store_forwards(
+                        step,
+                        &online_set,
+                        &mut context,
+                    ));
+                }
+                for envelope in forward_envelopes {
+                    let _ = post_envelope(&relay_base_url, &envelope).await;
+                }
+
+                for node_id in &newly_online {
+                    let envelopes = fetch_inbox(&relay_base_url, node_id)
+                        .await
+                        .unwrap_or_default();
+                    if let Some(client) = clients.get_mut(node_id) {
+                        let mut context = ClientContext {
+                            direct_enabled,
+                            ttl_seconds,
+                            encryption: encryption.clone(),
+                            direct_links,
+                            neighbors,
+                            keypairs,
+                            message_history: &mut *message_history,
+                            message_send_steps: &mut *message_send_steps,
+                            pending_forwarded_messages: &mut *pending_forwarded_messages,
+                            metrics: &mut *metrics,
+                            metrics_tracker: &mut *metrics_tracker,
+                            log_sink: &log_sink,
+                        };
+                        let newly_received = client.handle_inbox(
+                            step,
+                            envelopes,
+                            &mut context,
+                            Some(&mut rolling_latency),
+                        );
+                        received_messages = received_messages.saturating_add(newly_received);
+                    }
+                }
+
+                let mut online_envelopes = Vec::new();
+                for node_id in &newly_online {
+                    if let Some(client) = clients.get_mut(node_id) {
+                        let mut context = ClientContext {
+                            direct_enabled,
+                            ttl_seconds,
+                            encryption: encryption.clone(),
+                            direct_links,
+                            neighbors,
+                            keypairs,
+                            message_history: &mut *message_history,
+                            message_send_steps: &mut *message_send_steps,
+                            pending_forwarded_messages: &mut *pending_forwarded_messages,
+                            metrics: &mut *metrics,
+                            metrics_tracker: &mut *metrics_tracker,
+                            log_sink: &log_sink,
+                        };
+                        online_envelopes.extend(client.announce_online(step, &mut context));
+                    }
+                }
+                for envelope in online_envelopes {
+                    let _ = post_envelope(&relay_base_url, &envelope).await;
+                }
+
+                let mut broadcast_envelopes = Vec::new();
+                for client in clients.values_mut() {
+                    let mut context = ClientContext {
+                        direct_enabled,
+                        ttl_seconds,
+                        encryption: encryption.clone(),
+                        direct_links,
+                        neighbors,
+                        keypairs,
+                        message_history: &mut *message_history,
+                        message_send_steps: &mut *message_send_steps,
+                        pending_forwarded_messages: &mut *pending_forwarded_messages,
+                        metrics: &mut *metrics,
+                        metrics_tracker: &mut *metrics_tracker,
+                        log_sink: &log_sink,
+                    };
+                    let outcome =
+                        client.process_pending_online_broadcasts(step, &online_set, &mut context);
+                    received_messages = received_messages.saturating_add(outcome.delivered_missed);
+                    broadcast_envelopes.extend(outcome.envelopes);
+                }
+                for envelope in broadcast_envelopes {
+                    let _ = post_envelope(&relay_base_url, &envelope).await;
+                }
+
+                for node_id in &online_ids {
+                    if newly_online.contains(node_id) {
+                        continue;
+                    }
+                    let envelopes = fetch_inbox(&relay_base_url, node_id)
+                        .await
+                        .unwrap_or_default();
+                    if let Some(client) = clients.get_mut(node_id) {
+                        let mut context = ClientContext {
+                            direct_enabled,
+                            ttl_seconds,
+                            encryption: encryption.clone(),
+                            direct_links,
+                            neighbors,
+                            keypairs,
+                            message_history: &mut *message_history,
+                            message_send_steps: &mut *message_send_steps,
+                            pending_forwarded_messages: &mut *pending_forwarded_messages,
+                            metrics: &mut *metrics,
+                            metrics_tracker: &mut *metrics_tracker,
+                            log_sink: &log_sink,
+                        };
+                        let newly_received = client.handle_inbox(
+                            step,
+                            envelopes,
+                            &mut context,
+                            Some(&mut rolling_latency),
+                        );
+                        received_messages = received_messages.saturating_add(newly_received);
+                    }
+                }
+
+                for node_id in &online_ids {
+                    previous_online.insert(node_id.clone(), true);
+                }
+                for (node_id, was_online) in previous_online.iter_mut() {
+                    if !online_set.contains(node_id) {
+                        *was_online = false;
+                    }
+                }
+
+                (sent_messages, received_messages, online_ids.len())
+            };
+
+            let aggregate_metrics = self.aggregate_metrics();
             let update = SimulationStepUpdate {
                 step: step + 1,
                 total_steps: steps,
-                online_nodes: online_ids.len(),
-                total_peers: self.nodes.len(),
+                online_nodes,
+                total_peers: self.clients.len(),
                 speed_factor: self.timing.speed_factor,
                 sent_messages,
                 received_messages,
                 rolling_latency: rolling_latency.snapshot(),
-                aggregate_metrics: self.aggregate_metrics(),
+                aggregate_metrics,
             };
             on_step(update);
             let delay = self.timing.real_time_per_step();
@@ -1312,198 +1256,10 @@ impl SimulationHarness {
     }
 
     pub fn inbox(&self, node_id: &str) -> Vec<SimMessage> {
-        self.nodes
+        self.clients
             .get(node_id)
-            .map(|node| node.inbox.clone())
+            .map(|client| client.inbox())
             .unwrap_or_default()
-    }
-
-    async fn route_message(&mut self, step: usize, message: &SimMessage) -> Option<usize> {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let envelope = build_envelope_from_payload(
-            message.sender.clone(),
-            message.recipient.clone(),
-            None,
-            None,
-            timestamp,
-            self.ttl_seconds,
-            MessageKind::Direct,
-            None,
-            message.payload.clone(),
-        )
-        .ok()?;
-        self.record_message_send(message, step, &envelope);
-        let mut direct_latency = None;
-        let recipient_online = self
-            .nodes
-            .get(&message.recipient)
-            .is_some_and(|node| node.online_at(step));
-        if self.direct_enabled
-            && self
-                .direct_links
-                .contains(&(message.sender.clone(), message.recipient.clone()))
-        {
-            if recipient_online {
-                let decoded =
-                    self.decode_direct_envelope(&envelope, &message.id, &message.recipient);
-                if let Some(decoded) = decoded {
-                    if let Some(node) = self.nodes.get_mut(&message.recipient) {
-                        if node.receive(decoded.clone()) {
-                            direct_latency =
-                                self.record_delivery_metrics(&decoded, &message.recipient, step);
-                        }
-                    }
-                }
-            }
-        }
-
-        if !recipient_online {
-            if let Some(storage_peer_id) =
-                self.select_storage_peer(&message.sender, &message.recipient)
-            {
-                if let Some(store_envelope) = self.build_store_for_envelope(
-                    &message.sender,
-                    &storage_peer_id,
-                    &message.recipient,
-                    timestamp,
-                    &envelope,
-                ) {
-                    self.metrics_tracker
-                        .record_send(message, step, &store_envelope);
-                    let _ = post_envelope(&self.relay_base_url, &store_envelope).await;
-                    return direct_latency;
-                }
-            }
-        }
-
-        self.metrics_tracker.record_send(message, step, &envelope);
-        let _ = post_envelope(&self.relay_base_url, &envelope).await;
-
-        direct_latency
-    }
-
-    fn decode_envelope_action(
-        &self,
-        envelope: &Envelope,
-        recipient_id: &str,
-    ) -> Option<IncomingEnvelopeAction> {
-        if envelope.header.verify_signature(envelope.version).is_err() {
-            return None;
-        }
-        match envelope.header.message_kind {
-            MessageKind::Direct => self
-                .decode_direct_envelope(envelope, &envelope.header.message_id.0, recipient_id)
-                .map(IncomingEnvelopeAction::DirectMessage),
-            MessageKind::StoreForPeer => self
-                .decode_store_for_envelope(envelope, recipient_id)
-                .map(IncomingEnvelopeAction::StoredForPeer),
-            _ => None,
-        }
-    }
-
-    fn decode_direct_envelope(
-        &self,
-        envelope: &Envelope,
-        message_id: &str,
-        recipient_id: &str,
-    ) -> Option<SimMessage> {
-        if envelope.header.message_kind != MessageKind::Direct {
-            return None;
-        }
-        let body = match self.encryption {
-            MessageEncryption::Plaintext => envelope.payload.body.clone(),
-            MessageEncryption::Encrypted => {
-                let keypair = self.keypairs.get(recipient_id)?;
-                let plaintext = decrypt_encrypted_payload(
-                    &envelope.payload,
-                    &keypair.private_key_hex,
-                    SIMULATION_PAYLOAD_AAD,
-                    SIMULATION_HPKE_INFO,
-                )
-                .ok()?;
-                String::from_utf8(plaintext).ok()?
-            }
-        };
-        Some(SimMessage {
-            id: message_id.to_string(),
-            sender: envelope.header.sender_id.clone(),
-            recipient: envelope.header.recipient_id.clone(),
-            body,
-            payload: envelope.payload.clone(),
-        })
-    }
-
-    fn decode_store_for_envelope(
-        &self,
-        envelope: &Envelope,
-        storage_peer_id: &str,
-    ) -> Option<StoredForPeerMessage> {
-        if envelope.header.message_kind != MessageKind::StoreForPeer {
-            return None;
-        }
-        let store_for_id = envelope.header.store_for.clone()?;
-        let storage_peer = envelope.header.storage_peer_id.clone()?;
-        if storage_peer != storage_peer_id {
-            return None;
-        }
-        let keypair = self.keypairs.get(storage_peer_id)?;
-        let plaintext = decrypt_encrypted_payload(
-            &envelope.payload,
-            &keypair.private_key_hex,
-            SIMULATION_PAYLOAD_AAD,
-            SIMULATION_HPKE_INFO,
-        )
-        .ok()?;
-        let payload: StoreForPayload = serde_json::from_slice(&plaintext).ok()?;
-        Some(StoredForPeerMessage {
-            store_for_id,
-            envelope: payload.envelope,
-        })
-    }
-
-    fn build_store_for_envelope(
-        &self,
-        sender_id: &str,
-        storage_peer_id: &str,
-        store_for_id: &str,
-        timestamp: u64,
-        inner_envelope: &Envelope,
-    ) -> Option<Envelope> {
-        let keypair = self.keypairs.get(storage_peer_id)?;
-        let payload_bytes = serde_json::to_vec(&StoreForPayload {
-            envelope: inner_envelope.clone(),
-        })
-        .ok()?;
-        let mut rng = rand::thread_rng();
-        let mut content_key = [0u8; CONTENT_KEY_SIZE];
-        let mut nonce = [0u8; NONCE_SIZE];
-        rng.fill_bytes(&mut content_key);
-        rng.fill_bytes(&mut nonce);
-        let outer_payload = build_encrypted_payload(
-            &payload_bytes,
-            &keypair.public_key_hex,
-            SIMULATION_PAYLOAD_AAD,
-            SIMULATION_HPKE_INFO,
-            &content_key,
-            &nonce,
-            None,
-        )
-        .ok()?;
-        build_envelope_from_payload(
-            sender_id.to_string(),
-            storage_peer_id.to_string(),
-            Some(store_for_id.to_string()),
-            Some(storage_peer_id.to_string()),
-            timestamp,
-            self.ttl_seconds,
-            MessageKind::StoreForPeer,
-            None,
-            outer_payload,
-        )
-        .ok()
     }
 }
 
@@ -1833,7 +1589,7 @@ pub async fn run_simulation_scenario(
     let steps = scenario.simulation.effective_steps();
     let mut harness = SimulationHarness::new(
         base_url,
-        inputs.nodes,
+        inputs.clients,
         inputs.direct_links,
         scenario.direct_enabled.unwrap_or(true),
         relay_config.ttl_seconds,
@@ -1864,7 +1620,7 @@ where
     let steps = scenario.simulation.effective_steps();
     let mut harness = SimulationHarness::new(
         base_url,
-        inputs.nodes,
+        inputs.clients,
         inputs.direct_links,
         scenario.direct_enabled.unwrap_or(true),
         relay_config.ttl_seconds,
@@ -1957,7 +1713,7 @@ pub fn build_simulation_inputs(config: &SimulationConfig) -> SimulationInputs {
         },
     );
     let mut direct_links = HashSet::new();
-    let mut nodes = Vec::new();
+    let mut clients = Vec::new();
     for node_id in &config.node_ids {
         if let Some(friends) = graph.get(node_id) {
             for friend in friends {
@@ -1969,10 +1725,10 @@ pub fn build_simulation_inputs(config: &SimulationConfig) -> SimulationInputs {
             .get(node_id)
             .cloned()
             .unwrap_or_default();
-        nodes.push(Node::new(node_id, schedule));
+        clients.push(SimulationClient::new(node_id, schedule));
     }
     SimulationInputs {
-        nodes,
+        clients,
         planned_sends,
         direct_links,
         keypairs,

--- a/src/simulation/client.rs
+++ b/src/simulation/client.rs
@@ -1,0 +1,772 @@
+use std::collections::{HashMap, HashSet};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+
+use crate::crypto::{StoredKeypair, CONTENT_KEY_SIZE, NONCE_SIZE};
+use crate::protocol::{
+    build_encrypted_payload, build_envelope_from_payload, build_meta_payload,
+    decrypt_encrypted_payload, Envelope, MessageKind, MetaMessage,
+};
+
+use super::{
+    HistoricalMessage, MessageEncryption, MetricsTracker, RollingLatencyTracker, SimMessage,
+    SimulationMetrics, SIMULATION_ACK_WINDOW_STEPS, SIMULATION_HPKE_INFO, SIMULATION_PAYLOAD_AAD,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoreForPayload {
+    envelope: Envelope,
+}
+
+#[derive(Debug, Clone)]
+struct StoredForPeerMessage {
+    store_for_id: String,
+    envelope: Envelope,
+}
+
+#[derive(Debug, Clone)]
+struct PendingOnlineBroadcast {
+    sender_id: String,
+    recipient_id: String,
+    sent_step: usize,
+    expires_at: usize,
+}
+
+pub(crate) struct ClientContext<'a> {
+    pub direct_enabled: bool,
+    pub ttl_seconds: u64,
+    pub encryption: MessageEncryption,
+    pub direct_links: &'a HashSet<(String, String)>,
+    pub neighbors: &'a HashMap<String, Vec<String>>,
+    pub keypairs: &'a HashMap<String, StoredKeypair>,
+    pub message_history: &'a mut HashMap<(String, String), Vec<HistoricalMessage>>,
+    pub message_send_steps: &'a mut HashMap<String, usize>,
+    pub pending_forwarded_messages: &'a mut HashSet<String>,
+    pub metrics: &'a mut SimulationMetrics,
+    pub metrics_tracker: &'a mut MetricsTracker,
+    pub log_sink: &'a Option<std::sync::Arc<dyn Fn(String) + Send + Sync>>,
+}
+
+impl<'a> ClientContext<'a> {
+    fn log_action(&self, step: usize, message: impl Into<String>) {
+        if let Some(log_sink) = &self.log_sink {
+            log_sink(format!("[sim step={step}] {}", message.into()));
+        }
+    }
+}
+
+pub(crate) struct ClientSendOutcome {
+    pub envelopes: Vec<Envelope>,
+    pub direct_deliveries: Vec<SimMessage>,
+}
+
+pub(crate) struct ClientBroadcastOutcome {
+    pub envelopes: Vec<Envelope>,
+    pub delivered_missed: usize,
+}
+
+pub(crate) trait Client: Send {
+    fn id(&self) -> &str;
+    fn is_online(&self, step: usize) -> bool;
+    fn inbox(&self) -> Vec<SimMessage>;
+    fn stored_forward_count(&self) -> usize;
+    fn receive_message(&mut self, message: SimMessage) -> bool;
+
+    fn enqueue_sends(
+        &mut self,
+        step: usize,
+        messages: &[SimMessage],
+        online_set: &HashSet<String>,
+        context: &mut ClientContext<'_>,
+    ) -> ClientSendOutcome;
+
+    fn handle_inbox(
+        &mut self,
+        step: usize,
+        envelopes: Vec<Envelope>,
+        context: &mut ClientContext<'_>,
+        rolling_latency: Option<&mut RollingLatencyTracker>,
+    ) -> usize;
+
+    fn announce_online(&mut self, step: usize, context: &mut ClientContext<'_>) -> Vec<Envelope>;
+
+    fn process_pending_online_broadcasts(
+        &mut self,
+        step: usize,
+        online_set: &HashSet<String>,
+        context: &mut ClientContext<'_>,
+    ) -> ClientBroadcastOutcome;
+
+    fn forward_store_forwards(
+        &mut self,
+        step: usize,
+        online_set: &HashSet<String>,
+        context: &mut ClientContext<'_>,
+    ) -> Vec<Envelope>;
+
+    fn handle_direct_delivery(
+        &mut self,
+        step: usize,
+        message: SimMessage,
+        context: &mut ClientContext<'_>,
+        rolling_latency: Option<&mut RollingLatencyTracker>,
+    ) -> Option<usize>;
+}
+
+#[derive(Debug, Clone)]
+pub struct SimulationClient {
+    id: String,
+    schedule: Vec<bool>,
+    inbox: Vec<SimMessage>,
+    seen: HashSet<String>,
+    last_seen_by_peer: HashMap<String, u64>,
+    pending_online_broadcasts: Vec<PendingOnlineBroadcast>,
+    stored_forwards: Vec<StoredForPeerMessage>,
+}
+
+impl SimulationClient {
+    pub fn new(id: &str, schedule: Vec<bool>) -> Self {
+        Self {
+            id: id.to_string(),
+            schedule,
+            inbox: Vec::new(),
+            seen: HashSet::new(),
+            last_seen_by_peer: HashMap::new(),
+            pending_online_broadcasts: Vec::new(),
+            stored_forwards: Vec::new(),
+        }
+    }
+
+    fn record_message_send(
+        &self,
+        message: &SimMessage,
+        step: usize,
+        envelope: &Envelope,
+        context: &mut ClientContext<'_>,
+    ) {
+        context.message_send_steps.insert(message.id.clone(), step);
+        context
+            .message_history
+            .entry((message.sender.clone(), message.recipient.clone()))
+            .or_default()
+            .push(HistoricalMessage {
+                send_step: step,
+                envelope: envelope.clone(),
+            });
+    }
+
+    fn update_last_seen(
+        &mut self,
+        sender_id: &str,
+        message_id: &str,
+        context: &mut ClientContext<'_>,
+    ) {
+        let Some(send_step) = context.message_send_steps.get(message_id) else {
+            return;
+        };
+        let entry = self
+            .last_seen_by_peer
+            .entry(sender_id.to_string())
+            .or_insert(0);
+        *entry = (*entry).max(*send_step as u64);
+    }
+
+    fn last_seen_for(&self, sender_id: &str) -> u64 {
+        self.last_seen_by_peer.get(sender_id).copied().unwrap_or(0)
+    }
+
+    fn record_delivery_metrics(
+        &mut self,
+        message: &SimMessage,
+        step: usize,
+        context: &mut ClientContext<'_>,
+    ) -> Option<usize> {
+        if context.pending_forwarded_messages.remove(&message.id) {
+            context.metrics.store_forwards_delivered =
+                context.metrics.store_forwards_delivered.saturating_add(1);
+            context.metrics_tracker.record_store_forward_delivery();
+        }
+        let latency = context
+            .metrics_tracker
+            .record_delivery(&message.id, &self.id, step);
+        self.update_last_seen(&message.sender, &message.id, context);
+        latency
+    }
+
+    fn apply_delivery(
+        &mut self,
+        step: usize,
+        message: SimMessage,
+        context: &mut ClientContext<'_>,
+        delivery_kind: DeliveryKind,
+    ) -> Option<usize> {
+        if !self.receive_message(message.clone()) {
+            return None;
+        }
+        match delivery_kind {
+            DeliveryKind::Direct => {
+                context.metrics.direct_deliveries =
+                    context.metrics.direct_deliveries.saturating_add(1);
+            }
+            DeliveryKind::Inbox => {
+                context.metrics.inbox_deliveries =
+                    context.metrics.inbox_deliveries.saturating_add(1);
+            }
+            DeliveryKind::Missed => {
+                context.metrics_tracker.record_missed_message_delivery();
+            }
+        }
+        let latency = self.record_delivery_metrics(&message, step, context);
+        if matches!(delivery_kind, DeliveryKind::Missed) {
+            context.log_action(
+                step + 1,
+                format!("{} received missed message {}", self.id, message.id),
+            );
+        }
+        latency
+    }
+
+    fn build_meta_envelope(
+        &self,
+        sender_id: &str,
+        recipient_id: &str,
+        step: usize,
+        meta: &MetaMessage,
+        context: &mut ClientContext<'_>,
+    ) -> Option<Envelope> {
+        let payload = build_meta_payload(meta).ok()?;
+        let envelope = build_envelope_from_payload(
+            sender_id.to_string(),
+            recipient_id.to_string(),
+            None,
+            None,
+            step as u64,
+            context.ttl_seconds,
+            MessageKind::Meta,
+            None,
+            payload,
+        )
+        .ok()?;
+        context
+            .metrics_tracker
+            .record_meta_send(sender_id.to_string(), &envelope);
+        Some(envelope)
+    }
+
+    fn decode_direct_envelope(
+        &self,
+        envelope: &Envelope,
+        message_id: &str,
+        recipient_id: &str,
+        context: &ClientContext<'_>,
+    ) -> Option<SimMessage> {
+        if envelope.header.message_kind != MessageKind::Direct {
+            return None;
+        }
+        let body = match context.encryption {
+            MessageEncryption::Plaintext => envelope.payload.body.clone(),
+            MessageEncryption::Encrypted => {
+                let keypair = context.keypairs.get(recipient_id)?;
+                let plaintext = decrypt_encrypted_payload(
+                    &envelope.payload,
+                    &keypair.private_key_hex,
+                    SIMULATION_PAYLOAD_AAD,
+                    SIMULATION_HPKE_INFO,
+                )
+                .ok()?;
+                String::from_utf8(plaintext).ok()?
+            }
+        };
+        Some(SimMessage {
+            id: message_id.to_string(),
+            sender: envelope.header.sender_id.clone(),
+            recipient: envelope.header.recipient_id.clone(),
+            body,
+            payload: envelope.payload.clone(),
+        })
+    }
+
+    fn decode_store_for_envelope(
+        &self,
+        envelope: &Envelope,
+        storage_peer_id: &str,
+        context: &ClientContext<'_>,
+    ) -> Option<StoredForPeerMessage> {
+        if envelope.header.message_kind != MessageKind::StoreForPeer {
+            return None;
+        }
+        let store_for_id = envelope.header.store_for.clone()?;
+        let storage_peer = envelope.header.storage_peer_id.clone()?;
+        if storage_peer != storage_peer_id {
+            return None;
+        }
+        let keypair = context.keypairs.get(storage_peer_id)?;
+        let plaintext = decrypt_encrypted_payload(
+            &envelope.payload,
+            &keypair.private_key_hex,
+            SIMULATION_PAYLOAD_AAD,
+            SIMULATION_HPKE_INFO,
+        )
+        .ok()?;
+        let payload: StoreForPayload = serde_json::from_slice(&plaintext).ok()?;
+        Some(StoredForPeerMessage {
+            store_for_id,
+            envelope: payload.envelope,
+        })
+    }
+
+    fn build_store_for_envelope(
+        &self,
+        sender_id: &str,
+        storage_peer_id: &str,
+        store_for_id: &str,
+        timestamp: u64,
+        inner_envelope: &Envelope,
+        context: &ClientContext<'_>,
+    ) -> Option<Envelope> {
+        let keypair = context.keypairs.get(storage_peer_id)?;
+        let payload_bytes = serde_json::to_vec(&StoreForPayload {
+            envelope: inner_envelope.clone(),
+        })
+        .ok()?;
+        let mut rng = rand::thread_rng();
+        let mut content_key = [0u8; CONTENT_KEY_SIZE];
+        let mut nonce = [0u8; NONCE_SIZE];
+        rng.fill_bytes(&mut content_key);
+        rng.fill_bytes(&mut nonce);
+        let outer_payload = build_encrypted_payload(
+            &payload_bytes,
+            &keypair.public_key_hex,
+            SIMULATION_PAYLOAD_AAD,
+            SIMULATION_HPKE_INFO,
+            &content_key,
+            &nonce,
+            None,
+        )
+        .ok()?;
+        build_envelope_from_payload(
+            sender_id.to_string(),
+            storage_peer_id.to_string(),
+            Some(store_for_id.to_string()),
+            Some(storage_peer_id.to_string()),
+            timestamp,
+            context.ttl_seconds,
+            MessageKind::StoreForPeer,
+            None,
+            outer_payload,
+        )
+        .ok()
+    }
+
+    fn decode_envelope_action(
+        &self,
+        envelope: &Envelope,
+        recipient_id: &str,
+        context: &ClientContext<'_>,
+    ) -> Option<IncomingEnvelopeAction> {
+        if envelope.header.verify_signature(envelope.version).is_err() {
+            return None;
+        }
+        match envelope.header.message_kind {
+            MessageKind::Direct => self
+                .decode_direct_envelope(
+                    envelope,
+                    &envelope.header.message_id.0,
+                    recipient_id,
+                    context,
+                )
+                .map(IncomingEnvelopeAction::DirectMessage),
+            MessageKind::StoreForPeer => self
+                .decode_store_for_envelope(envelope, recipient_id, context)
+                .map(IncomingEnvelopeAction::StoredForPeer),
+            _ => None,
+        }
+    }
+
+    fn store_forward_message(
+        &mut self,
+        step: usize,
+        message: StoredForPeerMessage,
+        context: &mut ClientContext<'_>,
+    ) {
+        self.stored_forwards.push(message);
+        context.metrics.store_forwards_stored =
+            context.metrics.store_forwards_stored.saturating_add(1);
+        context.metrics_tracker.record_store_forward_stored();
+        context.log_action(
+            step + 1,
+            format!("{} stored a store-forward message", self.id),
+        );
+    }
+
+    fn select_storage_peer(
+        &self,
+        sender: &str,
+        recipient: &str,
+        context: &ClientContext<'_>,
+    ) -> Option<String> {
+        let sender_neighbors = context.neighbors.get(sender)?;
+        let recipient_neighbors = context.neighbors.get(recipient)?;
+        let sender_set: HashSet<&String> = sender_neighbors.iter().collect();
+        let mut mutual: Vec<String> = recipient_neighbors
+            .iter()
+            .filter(|candidate| sender_set.contains(candidate))
+            .cloned()
+            .collect();
+        mutual.sort();
+        mutual
+            .into_iter()
+            .find(|candidate| candidate != sender && candidate != recipient)
+    }
+
+    fn handle_message_request(
+        &mut self,
+        requester: &str,
+        responder: &str,
+        step: usize,
+        context: &mut ClientContext<'_>,
+    ) -> (Vec<Envelope>, usize) {
+        let last_seen = self.last_seen_for(responder);
+        let request = MetaMessage::MessageRequest {
+            peer_id: responder.to_string(),
+            since_timestamp: last_seen,
+        };
+        let mut envelopes = Vec::new();
+        if let Some(envelope) =
+            self.build_meta_envelope(requester, responder, step, &request, context)
+        {
+            envelopes.push(envelope);
+        }
+        context.metrics_tracker.record_missed_message_request();
+        context.log_action(
+            step + 1,
+            format!("{requester} requested missed messages from {responder}"),
+        );
+        let Some(history) = context
+            .message_history
+            .get(&(responder.to_string(), requester.to_string()))
+        else {
+            return (envelopes, 0);
+        };
+        let entries: Vec<HistoricalMessage> = history
+            .iter()
+            .filter(|entry| entry.send_step as u64 >= last_seen)
+            .cloned()
+            .collect();
+        let mut delivered = 0;
+        for entry in entries {
+            if self.deliver_missed_message(&entry.envelope, requester, step, context) {
+                delivered += 1;
+            }
+        }
+        if delivered > 0 {
+            context.log_action(
+                step + 1,
+                format!("{responder} delivered {delivered} missed messages to {requester}"),
+            );
+        }
+        (envelopes, delivered)
+    }
+
+    fn deliver_missed_message(
+        &mut self,
+        envelope: &Envelope,
+        recipient_id: &str,
+        step: usize,
+        context: &mut ClientContext<'_>,
+    ) -> bool {
+        let message_id = envelope.header.message_id.0.clone();
+        let message = self.decode_direct_envelope(envelope, &message_id, recipient_id, context);
+        let Some(message) = message else {
+            return false;
+        };
+        self.apply_delivery(step, message, context, DeliveryKind::Missed)
+            .is_some()
+    }
+
+    fn online_at(&self, step: usize) -> bool {
+        self.schedule.get(step).copied().unwrap_or(false)
+    }
+}
+
+impl Client for SimulationClient {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn is_online(&self, step: usize) -> bool {
+        self.online_at(step)
+    }
+
+    fn inbox(&self) -> Vec<SimMessage> {
+        self.inbox.clone()
+    }
+
+    fn stored_forward_count(&self) -> usize {
+        self.stored_forwards.len()
+    }
+
+    fn receive_message(&mut self, message: SimMessage) -> bool {
+        if self.seen.insert(message.id.clone()) {
+            self.inbox.push(message);
+            return true;
+        }
+        false
+    }
+
+    fn enqueue_sends(
+        &mut self,
+        step: usize,
+        messages: &[SimMessage],
+        online_set: &HashSet<String>,
+        context: &mut ClientContext<'_>,
+    ) -> ClientSendOutcome {
+        let mut envelopes = Vec::new();
+        let mut direct_deliveries = Vec::new();
+        for message in messages {
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let envelope = match build_envelope_from_payload(
+                message.sender.clone(),
+                message.recipient.clone(),
+                None,
+                None,
+                timestamp,
+                context.ttl_seconds,
+                MessageKind::Direct,
+                None,
+                message.payload.clone(),
+            ) {
+                Ok(envelope) => envelope,
+                Err(_) => continue,
+            };
+            self.record_message_send(message, step, &envelope, context);
+            let recipient_online = online_set.contains(&message.recipient);
+            if context.direct_enabled
+                && context
+                    .direct_links
+                    .contains(&(message.sender.clone(), message.recipient.clone()))
+                && recipient_online
+            {
+                if let Some(decoded) =
+                    self.decode_direct_envelope(&envelope, &message.id, &message.recipient, context)
+                {
+                    direct_deliveries.push(decoded);
+                }
+            }
+
+            if !recipient_online {
+                if let Some(storage_peer_id) =
+                    self.select_storage_peer(&message.sender, &message.recipient, context)
+                {
+                    if let Some(store_envelope) = self.build_store_for_envelope(
+                        &message.sender,
+                        &storage_peer_id,
+                        &message.recipient,
+                        timestamp,
+                        &envelope,
+                        context,
+                    ) {
+                        context
+                            .metrics_tracker
+                            .record_send(message, step, &store_envelope);
+                        envelopes.push(store_envelope);
+                        continue;
+                    }
+                }
+            }
+
+            context
+                .metrics_tracker
+                .record_send(message, step, &envelope);
+            envelopes.push(envelope);
+        }
+        ClientSendOutcome {
+            envelopes,
+            direct_deliveries,
+        }
+    }
+
+    fn handle_inbox(
+        &mut self,
+        step: usize,
+        envelopes: Vec<Envelope>,
+        context: &mut ClientContext<'_>,
+        mut rolling_latency: Option<&mut RollingLatencyTracker>,
+    ) -> usize {
+        let mut received = 0usize;
+        for envelope in envelopes {
+            match self.decode_envelope_action(&envelope, &self.id, context) {
+                Some(IncomingEnvelopeAction::DirectMessage(message)) => {
+                    if let Some(latency) =
+                        self.apply_delivery(step, message, context, DeliveryKind::Inbox)
+                    {
+                        if let Some(tracker) = rolling_latency.as_deref_mut() {
+                            tracker.record(latency);
+                        }
+                        received = received.saturating_add(1);
+                    }
+                }
+                Some(IncomingEnvelopeAction::StoredForPeer(message)) => {
+                    self.store_forward_message(step, message, context);
+                }
+                None => {}
+            }
+        }
+        received
+    }
+
+    fn announce_online(&mut self, step: usize, context: &mut ClientContext<'_>) -> Vec<Envelope> {
+        let Some(neighbors) = context.neighbors.get(&self.id) else {
+            return Vec::new();
+        };
+        if neighbors.is_empty() {
+            return Vec::new();
+        }
+        context.log_action(
+            step + 1,
+            format!("{} announced online to {}", self.id, neighbors.join(", ")),
+        );
+        let mut envelopes = Vec::new();
+        for neighbor in neighbors {
+            let meta = MetaMessage::Online {
+                peer_id: self.id.clone(),
+                timestamp: step as u64,
+            };
+            if let Some(envelope) =
+                self.build_meta_envelope(&self.id, neighbor, step, &meta, context)
+            {
+                envelopes.push(envelope);
+            }
+            self.pending_online_broadcasts.push(PendingOnlineBroadcast {
+                sender_id: self.id.clone(),
+                recipient_id: neighbor.clone(),
+                sent_step: step,
+                expires_at: step.saturating_add(SIMULATION_ACK_WINDOW_STEPS),
+            });
+            context.metrics_tracker.record_online_broadcast();
+        }
+        envelopes
+    }
+
+    fn process_pending_online_broadcasts(
+        &mut self,
+        step: usize,
+        online_set: &HashSet<String>,
+        context: &mut ClientContext<'_>,
+    ) -> ClientBroadcastOutcome {
+        let pending = std::mem::take(&mut self.pending_online_broadcasts);
+        let mut remaining = Vec::with_capacity(pending.len());
+        let mut delivered = 0usize;
+        let mut envelopes = Vec::new();
+        for pending in pending {
+            if step > pending.expires_at {
+                continue;
+            }
+            if online_set.contains(&pending.recipient_id) {
+                let ack = MetaMessage::Ack {
+                    peer_id: pending.recipient_id.clone(),
+                    online_timestamp: pending.sent_step as u64,
+                };
+                if let Some(envelope) = self.build_meta_envelope(
+                    &pending.recipient_id,
+                    &pending.sender_id,
+                    step,
+                    &ack,
+                    context,
+                ) {
+                    envelopes.push(envelope);
+                }
+                context.metrics_tracker.record_ack();
+                context.log_action(
+                    step + 1,
+                    format!(
+                        "{} acknowledged {} online",
+                        pending.recipient_id, pending.sender_id
+                    ),
+                );
+                let (request_envelopes, delivered_missed) = self.handle_message_request(
+                    &pending.sender_id,
+                    &pending.recipient_id,
+                    step,
+                    context,
+                );
+                envelopes.extend(request_envelopes);
+                delivered = delivered.saturating_add(delivered_missed);
+                continue;
+            }
+            remaining.push(pending);
+        }
+        self.pending_online_broadcasts = remaining;
+        ClientBroadcastOutcome {
+            envelopes,
+            delivered_missed: delivered,
+        }
+    }
+
+    fn forward_store_forwards(
+        &mut self,
+        step: usize,
+        online_set: &HashSet<String>,
+        context: &mut ClientContext<'_>,
+    ) -> Vec<Envelope> {
+        if !online_set.contains(&self.id) {
+            return Vec::new();
+        }
+        let mut forwarded = Vec::new();
+        let mut remaining = Vec::new();
+        for entry in self.stored_forwards.drain(..) {
+            if online_set.contains(&entry.store_for_id) {
+                let message_id = entry.envelope.header.message_id.0.clone();
+                context.pending_forwarded_messages.insert(message_id);
+                context.metrics.store_forwards_forwarded =
+                    context.metrics.store_forwards_forwarded.saturating_add(1);
+                context
+                    .metrics_tracker
+                    .record_store_forward_forwarded(&self.id);
+                context.log_action(
+                    step + 1,
+                    format!(
+                        "{} forwarded stored message to {}",
+                        self.id, entry.store_for_id
+                    ),
+                );
+                forwarded.push(entry.envelope);
+            } else {
+                remaining.push(entry);
+            }
+        }
+        self.stored_forwards = remaining;
+        forwarded
+    }
+
+    fn handle_direct_delivery(
+        &mut self,
+        step: usize,
+        message: SimMessage,
+        context: &mut ClientContext<'_>,
+        mut rolling_latency: Option<&mut RollingLatencyTracker>,
+    ) -> Option<usize> {
+        let latency = self.apply_delivery(step, message, context, DeliveryKind::Direct)?;
+        if let Some(tracker) = rolling_latency.as_deref_mut() {
+            tracker.record(latency);
+        }
+        Some(latency)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DeliveryKind {
+    Direct,
+    Inbox,
+    Missed,
+}
+
+enum IncomingEnvelopeAction {
+    DirectMessage(SimMessage),
+    StoredForPeer(StoredForPeerMessage),
+}


### PR DESCRIPTION
### Motivation

- Reduce per-peer complexity in the harness by moving peer-specific behavior into a dedicated client abstraction for clearer separation of concerns.
- Enable driving peer behavior through a minimal trait so the simulation can operate against any client implementation.
- Prepare the codebase for further client-side features (e.g., alternative client implementations or testing stubs) while keeping relay/network helpers shared.

### Description

- Add a new client module `src/simulation/client.rs` defining a `Client` trait, a `ClientContext`, and a concrete `SimulationClient` that owns per-peer state and behavior (`enqueue_sends`, `handle_inbox`, `announce_online`, `process_pending_online_broadcasts`, `forward_store_forwards`, `handle_direct_delivery`).
- Refactor `SimulationHarness` to store `clients: HashMap<String, Box<dyn Client>>` and delegate send/inbox/handshake/store-forward flows to the client interface, while keeping relay interactions in the harness code and small helper logic in `ClientContext`.
- Update input construction and wiring by producing `SimulationClient` instances from `build_simulation_inputs` and changing `SimulationInputs` to hold `clients` instead of `nodes`.
- Update the simulation TUI/CLI and tests to construct and add `SimulationClient` instances and adjusted exports in `src/simulation.rs` to expose `SimulationClient`.

### Testing

- Ran `cargo fmt` and formatting completed successfully.
- Ran `cargo build` and the project built successfully with warnings only, no errors.
- Ran `cargo test` and the test suite passed; the simulation harness tests in `tests/simulation_harness_tests.rs` (4 tests) and the rest of the automated tests all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aeec42d708325b32ef6337bb093a8)