### PR TITLE
Add client metrics and logging hooks

### DIFF
--- a/src/bin/simulation.rs
+++ b/src/bin/simulation.rs
@@ -638,7 +638,7 @@ fn handle_key_event(
                     trimmed.to_string()
                 };
                 let schedule = vec![true; total_steps];
-                let client = tenet::simulation::SimulationClient::new(&node_id, schedule);
+                let client = tenet::simulation::SimulationClient::new(&node_id, schedule, None);
                 let keypair = generate_keypair();
                 let _ = control_tx.send(SimulationControlCommand::AddPeer { client, keypair });
                 *input_mode = InputMode::Normal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
+pub mod client;
 pub mod crypto;
 pub mod protocol;
 pub mod relay;
 pub mod simulation;
-pub mod client;

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -120,8 +120,8 @@ async fn simulation_harness_tracks_online_handshake_metrics() {
     let (base_url, shutdown_tx, _relay_control) = start_relay(relay_config.clone()).await;
 
     let clients = vec![
-        tenet::simulation::SimulationClient::new("node-a", vec![false, true]),
-        tenet::simulation::SimulationClient::new("node-b", vec![true, true]),
+        tenet::simulation::SimulationClient::new("node-a", vec![false, true], None),
+        tenet::simulation::SimulationClient::new("node-b", vec![true, true], None),
     ];
     let mut direct_links = HashSet::new();
     direct_links.insert(("node-a".to_string(), "node-b".to_string()));
@@ -170,8 +170,8 @@ async fn simulation_harness_delivers_missed_messages_after_handshake() {
     let (base_url, shutdown_tx, _relay_control) = start_relay(relay_config.clone()).await;
 
     let clients = vec![
-        tenet::simulation::SimulationClient::new("node-a", vec![false, true, true]),
-        tenet::simulation::SimulationClient::new("node-b", vec![true, true, true]),
+        tenet::simulation::SimulationClient::new("node-a", vec![false, true, true], None),
+        tenet::simulation::SimulationClient::new("node-b", vec![true, true, true], None),
     ];
     let mut direct_links = HashSet::new();
     direct_links.insert(("node-a".to_string(), "node-b".to_string()));
@@ -235,8 +235,8 @@ async fn simulation_harness_applies_dynamic_updates() {
     let (base_url, shutdown_tx, _relay_control) = start_relay(relay_config.clone()).await;
 
     let clients = vec![
-        SimulationClient::new("node-a", vec![true; 4]),
-        SimulationClient::new("node-b", vec![true; 4]),
+        SimulationClient::new("node-a", vec![true; 4], None),
+        SimulationClient::new("node-b", vec![true; 4], None),
     ];
     let mut direct_links = HashSet::new();
     direct_links.insert(("node-a".to_string(), "node-b".to_string()));
@@ -261,7 +261,7 @@ async fn simulation_harness_applies_dynamic_updates() {
     );
 
     let (control_tx, control_rx) = mpsc::unbounded_channel();
-    let node_c = SimulationClient::new("node-c", vec![true; 4]);
+    let node_c = SimulationClient::new("node-c", vec![true; 4], None);
     let _ = control_tx.send(SimulationControlCommand::AddPeer {
         client: node_c,
         keypair: generate_keypair(),


### PR DESCRIPTION
### Motivation
- Capture per-client statistics for send/delivery/store-forward operations and expose them to simulation reporting. 
- Allow client-level log events to be forwarded into the harness log sink so client activity can be observed by the simulation runner.

### Description
- Introduced `ClientMetrics` and `ClientLogEvent` types and a `ClientLogSink` trait, and implemented them for closures via `impl<F> ClientLogSink for F` so sinks can be provided as `Arc<dyn ClientLogSink>`.
- Extended `SimulationClient` with a `metrics: ClientMetrics` field and an optional `log_sink` plus `set_log_sink()` and `log_action()` helpers, and updated client operations to increment per-client counters (e.g., `messages_sent`, `direct_deliveries`, `inbox_deliveries`, `missed_deliveries`, `store_forwards_*`).
- Wired a client log adapter into `SimulationHarness` that maps `ClientLogEvent` to the harness `log_sink`, and set client log sinks during harness construction and when adding peers dynamically via `SimulationControlCommand::AddPeer`.
- Aggregated per-client `ClientMetrics` in `SimulationAggregateMetrics` via a new `collect_client_metrics()` pass used when building an aggregate metrics report, and updated call sites to pass the new `log_sink`/constructor argument (`SimulationClient::new(..., None)` where appropriate).

### Testing
- Ran `cargo fmt` successfully to format the codebase.
- Ran `cargo build` successfully (build completed with unrelated warnings about unused fields in `src/simulation.rs` and `src/bin/toy_ui.rs`).
- Ran the test suite via `cargo test` and all tests passed (with the same non-blocking warnings reported during build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afee7bb288325b4c655cdf8697fb3)