### PR TITLE
Introduce RelayClient and refactor binaries to use shared client module

### DIFF
--- a/src/bin/simulation.rs
+++ b/src/bin/simulation.rs
@@ -19,11 +19,11 @@ use ratatui::widgets::{Block, Borders, Gauge, Paragraph};
 use ratatui::Terminal;
 use tokio::sync::mpsc;
 
-use tenet::crypto::generate_keypair;
 use tenet::protocol::MessageKind;
 use tenet::simulation::{
     run_simulation_scenario, CountSummary, RollingLatencySnapshot, SimulationAggregateMetrics,
-    SimulationControlCommand, SimulationScenarioConfig, SimulationStepUpdate, SizeSummary,
+    SimulationControlCommand, SimulationHarness, SimulationScenarioConfig, SimulationStepUpdate,
+    SizeSummary,
 };
 
 const MESSAGE_KIND_ORDER: [MessageKind; 5] = [
@@ -638,8 +638,7 @@ fn handle_key_event(
                     trimmed.to_string()
                 };
                 let schedule = vec![true; total_steps];
-                let client = tenet::simulation::SimulationClient::new(&node_id, schedule, None);
-                let keypair = generate_keypair();
+                let (client, keypair) = SimulationHarness::build_peer(&node_id, schedule);
                 let _ = control_tx.send(SimulationControlCommand::AddPeer { client, keypair });
                 *input_mode = InputMode::Normal;
                 *status_message = format!("Added peer request queued for {node_id}.");

--- a/src/bin/toy_ui.rs
+++ b/src/bin/toy_ui.rs
@@ -1,68 +1,35 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::env;
 use std::error::Error;
 use std::io::{self, Write};
-use std::time::{SystemTime, UNIX_EPOCH};
 
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use base64::Engine as _;
 use rustyline::error::ReadlineError;
 use rustyline::DefaultEditor;
-use serde::{Deserialize, Serialize};
 
-use tenet::crypto::{
-    decrypt_payload, encrypt_payload, generate_content_key, generate_keypair, unwrap_content_key,
-    wrap_content_key, StoredKeypair, WrappedKey,
-};
-use tenet::protocol::{ContentId, Envelope, Header, MessageKind, Payload, ProtocolVersion};
+use tenet::client::{ClientConfig, ClientEncryption, RelayClient};
+use tenet::crypto::generate_keypair;
 
 const DEFAULT_RELAY_URL: &str = "http://127.0.0.1:8080";
 const DEFAULT_TTL_SECONDS: u64 = 3600;
-const ENVELOPE_CONTENT_TYPE: &str = "application/json;type=tenet.encrypted";
 const HPKE_INFO: &[u8] = b"tenet-hpke";
 const PAYLOAD_AAD: &[u8] = b"tenet-toy-ui";
 const PROMPT: &str = "\x1b[1;34mtenet-debugger>\x1b[0m ";
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct WrappedKeyPayload {
-    enc_b64: String,
-    ciphertext_b64: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct EncryptedPayload {
-    nonce_b64: String,
-    ciphertext_b64: String,
-    wrapped_key: WrappedKeyPayload,
-}
-
-#[derive(Debug, Clone)]
-struct FeedMessage {
-    message_id: String,
-    from_name: String,
-    from_id: String,
-    timestamp: u64,
-    body: String,
-}
-
 #[derive(Debug)]
-struct PeerState {
+struct ToyPeer {
     name: String,
-    keypair: StoredKeypair,
-    online: bool,
-    feed: Vec<FeedMessage>,
-    seen: HashSet<String>,
+    client: RelayClient,
 }
 
-impl PeerState {
+impl ToyPeer {
     fn id(&self) -> &str {
-        &self.keypair.id
+        self.client.id()
     }
 }
 
 #[derive(Debug)]
 struct ToyUiConfig {
-    relay_url: String,
+    client_config: ClientConfig,
     peers: usize,
 }
 
@@ -75,13 +42,13 @@ fn main() {
 
 fn run() -> Result<(), Box<dyn Error>> {
     let config = parse_config()?;
-    let mut peers = spawn_peers(config.peers);
+    let mut peers = spawn_peers(config.peers, &config.client_config);
     let peer_directory = build_peer_directory(&peers);
 
     println!(
         "Toy UI started with {} peers. Relay: {}",
         peers.len(),
-        config.relay_url
+        config.client_config.relay_url()
     );
     print_help();
 
@@ -102,8 +69,7 @@ fn run() -> Result<(), Box<dyn Error>> {
                     break;
                 }
 
-                if let Err(error) =
-                    handle_command(input, &config, &mut peers, &peer_directory, &mut stdout)
+                if let Err(error) = handle_command(input, &mut peers, &peer_directory, &mut stdout)
                 {
                     eprintln!("error: {error}");
                 }
@@ -152,28 +118,40 @@ fn parse_config() -> Result<ToyUiConfig, Box<dyn Error>> {
 
     let peers = peers.unwrap_or(3).max(1);
 
-    Ok(ToyUiConfig { relay_url, peers })
+    let client_config = ClientConfig::new(
+        relay_url,
+        DEFAULT_TTL_SECONDS,
+        ClientEncryption::Encrypted {
+            hpke_info: HPKE_INFO.to_vec(),
+            payload_aad: PAYLOAD_AAD.to_vec(),
+        },
+    );
+
+    Ok(ToyUiConfig {
+        client_config,
+        peers,
+    })
 }
 
-fn spawn_peers(count: usize) -> Vec<PeerState> {
+fn spawn_peers(count: usize, client_config: &ClientConfig) -> Vec<ToyPeer> {
     (1..=count)
-        .map(|index| PeerState {
-            name: format!("peer-{index}"),
-            keypair: generate_keypair(),
-            online: true,
-            feed: Vec::new(),
-            seen: HashSet::new(),
+        .map(|index| {
+            let keypair = generate_keypair();
+            ToyPeer {
+                name: format!("peer-{index}"),
+                client: RelayClient::new(keypair, client_config.clone()),
+            }
         })
         .collect()
 }
 
-fn build_peer_directory(peers: &[PeerState]) -> HashMap<String, (String, String)> {
+fn build_peer_directory(peers: &[ToyPeer]) -> HashMap<String, (String, String)> {
     peers
         .iter()
         .map(|peer| {
             (
-                peer.keypair.id.clone(),
-                (peer.name.clone(), peer.keypair.public_key_hex.clone()),
+                peer.client.id().to_string(),
+                (peer.name.clone(), peer.client.public_key_hex().to_string()),
             )
         })
         .collect()
@@ -195,8 +173,7 @@ fn print_help() {
 
 fn handle_command(
     input: &str,
-    config: &ToyUiConfig,
-    peers: &mut [PeerState],
+    peers: &mut [ToyPeer],
     peer_directory: &HashMap<String, (String, String)>,
     stdout: &mut io::Stdout,
 ) -> Result<(), Box<dyn Error>> {
@@ -212,7 +189,7 @@ fn handle_command(
             let from = parts.next();
             let to = parts.next();
             let message = parts.collect::<Vec<_>>().join(" ");
-            send_message(config, peers, from, to, message)?;
+            send_message(peers, from, to, message)?;
         }
         "sync" => {
             let target = parts.next();
@@ -220,11 +197,11 @@ fn handle_command(
                 .next()
                 .map(|value| value.parse::<usize>())
                 .transpose()?;
-            sync_peers(config, peers, peer_directory, target, limit)?;
+            sync_peers(peers, target, limit)?;
         }
         "feed" => {
             let target = parts.next();
-            show_feed(peers, target, stdout)?;
+            show_feed(peers, peer_directory, target, stdout)?;
         }
         _ => println!("Unknown command: {command}"),
     }
@@ -232,7 +209,7 @@ fn handle_command(
     Ok(())
 }
 
-fn list_peers(peers: &[PeerState], stdout: &mut io::Stdout) -> Result<(), Box<dyn Error>> {
+fn list_peers(peers: &[ToyPeer], stdout: &mut io::Stdout) -> Result<(), Box<dyn Error>> {
     writeln!(stdout, "Peers:")?;
     for peer in peers {
         writeln!(
@@ -240,31 +217,38 @@ fn list_peers(peers: &[PeerState], stdout: &mut io::Stdout) -> Result<(), Box<dy
             "- {} (id: {}) [{}]",
             peer.name,
             peer.id(),
-            if peer.online { "online" } else { "offline" }
+            if peer.client.is_online() {
+                "online"
+            } else {
+                "offline"
+            }
         )?;
     }
     Ok(())
 }
 
 fn toggle_peer(
-    peers: &mut [PeerState],
+    peers: &mut [ToyPeer],
     name: Option<&str>,
     online: bool,
 ) -> Result<(), Box<dyn Error>> {
     let name = name.ok_or("peer name required")?;
     let peer = find_peer_mut(peers, name)?;
-    peer.online = online;
+    peer.client.set_online(online);
     println!(
         "{} is now {}",
         peer.name,
-        if peer.online { "online" } else { "offline" }
+        if peer.client.is_online() {
+            "online"
+        } else {
+            "offline"
+        }
     );
     Ok(())
 }
 
 fn send_message(
-    config: &ToyUiConfig,
-    peers: &mut [PeerState],
+    peers: &mut [ToyPeer],
     from: Option<&str>,
     to: Option<&str>,
     message: String,
@@ -278,20 +262,21 @@ fn send_message(
     let (recipient_id, recipient_public_key_hex) = {
         let recipient = find_peer(peers, to)?;
         (
-            recipient.keypair.id.clone(),
-            recipient.keypair.public_key_hex.clone(),
+            recipient.client.id().to_string(),
+            recipient.client.public_key_hex().to_string(),
         )
     };
 
     let sender = find_peer_mut(peers, from)?;
-    if !sender.online {
+    if !sender.client.is_online() {
         println!("{} is offline; cannot send", sender.name);
         return Ok(());
     }
 
-    let envelope = build_envelope(sender, &recipient_id, &recipient_public_key_hex, &message)?;
-
-    post_envelope(config, &envelope)?;
+    let envelope =
+        sender
+            .client
+            .send_message(&recipient_id, &recipient_public_key_hex, &message)?;
 
     println!(
         "sent message {} -> {} (message_id: {})",
@@ -301,55 +286,55 @@ fn send_message(
 }
 
 fn sync_peers(
-    config: &ToyUiConfig,
-    peers: &mut [PeerState],
-    peer_directory: &HashMap<String, (String, String)>,
+    peers: &mut [ToyPeer],
     target: Option<&str>,
     limit: Option<usize>,
 ) -> Result<(), Box<dyn Error>> {
     let target = target.ok_or("sync requires <peer_name|all>")?;
     if target == "all" {
         for peer in peers.iter_mut() {
-            if peer.online {
-                sync_peer(config, peer, peer_directory, limit)?;
+            if peer.client.is_online() {
+                sync_peer(peer, limit)?;
             }
         }
         return Ok(());
     }
 
     let peer = find_peer_mut(peers, target)?;
-    if !peer.online {
+    if !peer.client.is_online() {
         println!("{} is offline; cannot sync", peer.name);
         return Ok(());
     }
-    sync_peer(config, peer, peer_directory, limit)?;
+    sync_peer(peer, limit)?;
     Ok(())
 }
 
 fn show_feed(
-    peers: &[PeerState],
+    peers: &[ToyPeer],
+    peer_directory: &HashMap<String, (String, String)>,
     target: Option<&str>,
     stdout: &mut io::Stdout,
 ) -> Result<(), Box<dyn Error>> {
     let target = target.ok_or("feed requires <peer_name>")?;
     let peer = find_peer(peers, target)?;
     writeln!(stdout, "Feed for {}:", peer.name)?;
-    if peer.feed.is_empty() {
+    if peer.client.feed().is_empty() {
         writeln!(stdout, "(empty)")?;
         return Ok(());
     }
 
-    for message in &peer.feed {
+    for message in peer.client.feed() {
+        let (from_name, _) = peer_directory_lookup(peer_directory, &message.sender_id);
         writeln!(
             stdout,
             "- [{}] {} ({}) -> {}",
-            message.timestamp, message.from_name, message.from_id, message.body
+            message.timestamp, from_name, message.sender_id, message.body
         )?;
     }
     Ok(())
 }
 
-fn find_peer<'a>(peers: &'a [PeerState], name: &str) -> Result<&'a PeerState, Box<dyn Error>> {
+fn find_peer<'a>(peers: &'a [ToyPeer], name: &str) -> Result<&'a ToyPeer, Box<dyn Error>> {
     peers
         .iter()
         .find(|peer| peer.name == name)
@@ -357,171 +342,36 @@ fn find_peer<'a>(peers: &'a [PeerState], name: &str) -> Result<&'a PeerState, Bo
 }
 
 fn find_peer_mut<'a>(
-    peers: &'a mut [PeerState],
+    peers: &'a mut [ToyPeer],
     name: &str,
-) -> Result<&'a mut PeerState, Box<dyn Error>> {
+) -> Result<&'a mut ToyPeer, Box<dyn Error>> {
     peers
         .iter_mut()
         .find(|peer| peer.name == name)
         .ok_or_else(|| format!("unknown peer: {name}").into())
 }
 
-fn build_envelope(
-    sender: &PeerState,
-    recipient_id: &str,
-    recipient_public_key_hex: &str,
-    message: &str,
-) -> Result<Envelope, Box<dyn Error>> {
-    let content_key = generate_content_key();
-    let (nonce, ciphertext) = encrypt_payload(&content_key, message.as_bytes(), PAYLOAD_AAD, None)?;
-    let recipient_public_key_bytes = hex::decode(recipient_public_key_hex)?;
-    let wrapped = wrap_content_key(&recipient_public_key_bytes, &content_key, HPKE_INFO, None)?;
-
-    let encrypted_payload = EncryptedPayload {
-        nonce_b64: URL_SAFE_NO_PAD.encode(nonce),
-        ciphertext_b64: URL_SAFE_NO_PAD.encode(ciphertext),
-        wrapped_key: WrappedKeyPayload {
-            enc_b64: URL_SAFE_NO_PAD.encode(&wrapped.enc),
-            ciphertext_b64: URL_SAFE_NO_PAD.encode(&wrapped.ciphertext),
-        },
-    };
-
-    let payload_body = serde_json::to_string(&encrypted_payload)?;
-    let payload_id = ContentId::from_bytes(payload_body.as_bytes());
-    let payload = Payload {
-        id: payload_id,
-        content_type: ENVELOPE_CONTENT_TYPE.to_string(),
-        body: payload_body,
-        attachments: Vec::new(),
-    };
-
-    let message_id = ContentId::from_value(&payload)?;
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-
-    let mut header = Header {
-        sender_id: sender.keypair.id.clone(),
-        recipient_id: recipient_id.to_string(),
-        store_for: None,
-        storage_peer_id: None,
-        timestamp,
-        message_id,
-        message_kind: MessageKind::Direct,
-        group_id: None,
-        ttl_seconds: DEFAULT_TTL_SECONDS,
-        payload_size: payload.body.len() as u64,
-        signature: None,
-    };
-
-    let signature = header.expected_signature(ProtocolVersion::V1)?;
-    header.signature = Some(signature);
-
-    Ok(Envelope {
-        version: ProtocolVersion::V1,
-        header,
-        payload,
-    })
-}
-
-fn post_envelope(config: &ToyUiConfig, envelope: &Envelope) -> Result<(), Box<dyn Error>> {
-    let url = format!("{}/envelopes", config.relay_url.trim_end_matches('/'));
-    let response = ureq::post(&url).send_json(serde_json::to_value(envelope)?);
-
-    match response {
-        Ok(_) => Ok(()),
-        Err(ureq::Error::Status(code, _)) => Err(format!("relay error: {code}").into()),
-        Err(err) => Err(err.into()),
-    }
-}
-
-fn sync_peer(
-    config: &ToyUiConfig,
-    peer: &mut PeerState,
-    peer_directory: &HashMap<String, (String, String)>,
-    limit: Option<usize>,
-) -> Result<(), Box<dyn Error>> {
-    let url = if let Some(limit) = limit {
-        format!(
-            "{}/inbox/{}?limit={}",
-            config.relay_url.trim_end_matches('/'),
-            peer.id(),
-            limit
-        )
-    } else {
-        format!(
-            "{}/inbox/{}",
-            config.relay_url.trim_end_matches('/'),
-            peer.id()
-        )
-    };
-
-    let response = ureq::get(&url).call()?;
-    let envelopes: Vec<Envelope> = response.into_json()?;
-
-    if envelopes.is_empty() {
+fn sync_peer(peer: &mut ToyPeer, limit: Option<usize>) -> Result<(), Box<dyn Error>> {
+    let outcome = peer.client.sync_inbox(limit)?;
+    if outcome.fetched == 0 {
         println!("{} inbox is empty", peer.name);
         return Ok(());
     }
 
-    for envelope in envelopes {
-        if peer.seen.contains(&envelope.header.message_id.0) {
-            continue;
-        }
-        match decrypt_envelope(peer, peer_directory, &envelope) {
-            Ok(message) => {
-                peer.seen.insert(envelope.header.message_id.0.clone());
-                peer.feed.push(message);
-            }
-            Err(error) => {
-                println!("{} failed to decrypt message: {error}", peer.name);
-            }
-        }
+    for error in outcome.errors {
+        println!("{} failed to decrypt message: {error}", peer.name);
     }
 
-    println!("{} synced {} messages", peer.name, peer.feed.len());
+    println!("{} synced {} messages", peer.name, peer.client.feed().len());
     Ok(())
 }
 
-fn decrypt_envelope(
-    peer: &PeerState,
+fn peer_directory_lookup(
     peer_directory: &HashMap<String, (String, String)>,
-    envelope: &Envelope,
-) -> Result<FeedMessage, Box<dyn Error>> {
-    envelope
-        .header
-        .verify_signature(envelope.version)
-        .map_err(|error| format!("invalid header signature: {error:?}"))?;
-    if envelope.header.message_kind != MessageKind::Direct {
-        return Err(format!(
-            "unexpected message kind: {:?}",
-            envelope.header.message_kind
-        )
-        .into());
-    }
-    let encrypted_payload: EncryptedPayload = serde_json::from_str(&envelope.payload.body)?;
-    let wrapped = WrappedKey {
-        enc: URL_SAFE_NO_PAD.decode(encrypted_payload.wrapped_key.enc_b64.as_bytes())?,
-        ciphertext: URL_SAFE_NO_PAD
-            .decode(encrypted_payload.wrapped_key.ciphertext_b64.as_bytes())?,
-    };
-
-    let private_key_bytes = hex::decode(&peer.keypair.private_key_hex)?;
-    let content_key = unwrap_content_key(&private_key_bytes, &wrapped, HPKE_INFO)?;
-    let nonce = URL_SAFE_NO_PAD.decode(encrypted_payload.nonce_b64.as_bytes())?;
-    let ciphertext = URL_SAFE_NO_PAD.decode(encrypted_payload.ciphertext_b64.as_bytes())?;
-    let plaintext = decrypt_payload(&content_key, &nonce, &ciphertext, PAYLOAD_AAD)?;
-
-    let (from_name, _) = peer_directory
-        .get(&envelope.header.sender_id)
+    sender_id: &str,
+) -> (String, String) {
+    peer_directory
+        .get(sender_id)
         .cloned()
-        .unwrap_or_else(|| ("unknown".to_string(), "".to_string()));
-
-    let body = String::from_utf8(plaintext)?;
-
-    Ok(FeedMessage {
-        message_id: envelope.header.message_id.0.clone(),
-        from_name,
-        from_id: envelope.header.sender_id.clone(),
-        timestamp: envelope.header.timestamp,
-        body,
-    })
+        .unwrap_or_else(|| ("unknown".to_string(), "".to_string()))
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -10,7 +10,9 @@ use rand_distr::{Distribution, LogNormal, Normal};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot};
 
-use crate::crypto::{generate_keypair_with_rng, StoredKeypair, CONTENT_KEY_SIZE, NONCE_SIZE};
+use crate::crypto::{
+    generate_keypair, generate_keypair_with_rng, StoredKeypair, CONTENT_KEY_SIZE, NONCE_SIZE,
+};
 use crate::protocol::{
     build_encrypted_payload, build_plaintext_payload, ContentId, Envelope, MessageKind, Payload,
 };
@@ -465,6 +467,14 @@ pub struct SimulationHarness {
 }
 
 impl SimulationHarness {
+    pub fn build_client(node_id: &str, schedule: Vec<bool>) -> SimulationClient {
+        SimulationClient::new(node_id, schedule, None)
+    }
+
+    pub fn build_peer(node_id: &str, schedule: Vec<bool>) -> (SimulationClient, StoredKeypair) {
+        (Self::build_client(node_id, schedule), generate_keypair())
+    }
+
     pub fn new(
         relay_base_url: String,
         clients: Vec<SimulationClient>,
@@ -1736,7 +1746,7 @@ pub fn build_simulation_inputs(config: &SimulationConfig) -> SimulationInputs {
             .get(node_id)
             .cloned()
             .unwrap_or_default();
-        clients.push(SimulationClient::new(node_id, schedule, None));
+        clients.push(SimulationHarness::build_client(node_id, schedule));
     }
     SimulationInputs {
         clients,


### PR DESCRIPTION
### Motivation
- Centralize relay-backed peer behavior (send/sync, config, encryption) into a reusable client abstraction so binaries stop duplicating PeerState/crypto handling.
- Ensure relay URL, TTL and encryption mode are passed consistently via a client constructor/builder.
- Use shared simulation helpers so peers/clients are created consistently across the simulation harness and UI.

### Description
- Add a lightweight client module in `src/client.rs` exposing `ClientConfig`, `ClientEncryption`, `RelayClient`, `ClientMessage`, `SyncOutcome` and error types, with `send_message` and `sync_inbox` helpers that build envelopes and call the relay.
- Refactor the toy debugger UI (`src/bin/toy_ui.rs`) to replace local `PeerState`/message-handling with `ToyPeer` that contains a `RelayClient`, and map debugger commands to `RelayClient` operations.
- Update the CLI `src/bin/tenet-crypto.rs` to construct a `RelayClient` and use it for sending and syncing instead of inline crypto/HTTP logic.
- Add `SimulationHarness::build_client` and `SimulationHarness::build_peer` helpers in `src/simulation.rs` and wire TUI and tests to use them when creating simulation peers/clients.
- Update tests that constructed `SimulationClient` directly to use the new `SimulationHarness` builders.

### Testing
- Ran `cargo fmt` to format the codebase (completed successfully).
- Ran `cargo build` which completed successfully with an existing non-blocking warning in `src/simulation.rs` (unchanged semantic behavior).
- Ran `cargo test` and all tests passed (unit and harness tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b3368ce6883258567249364b699c7)