### PR TITLE
Add Ed25519 signatures and create implementation plan for public/group messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,9 +356,11 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -396,6 +404,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1090,6 +1123,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,6 +1561,16 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1597,6 +1659,7 @@ dependencies = [
  "base64",
  "chacha20poly1305",
  "crossterm",
+ "ed25519-dalek",
  "hex",
  "hpke",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ base64 = "0.22"
 chacha20poly1305 = { version = "0.10", features = ["std"] }
 axum = "0.7"
 crossterm = "0.27"
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 hex = "0.4"
 hpke = "0.11"
 rand = "0.8"

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,373 @@
+# Tenet Project Assessment & Implementation Plan
+
+## Current State Assessment
+
+### ✅ What's Working Well
+
+**Core Protocol** (src/protocol.rs):
+- Message types defined: `Public`, `Meta`, `Direct`, `FriendGroup`, `StoreForPeer`
+- Headers with signatures, TTL, message IDs
+- Validation rules for message kinds
+- Content-addressed IDs using SHA256
+- Envelope serialization/deserialization
+
+**Cryptography** (src/crypto.rs):
+- HPKE key encapsulation for per-recipient encryption
+- ChaCha20Poly1305 authenticated encryption
+- X25519 keypairs and key derivation
+- Content key generation
+
+**Relay Server** (src/relay.rs):
+- HTTP relay with Axum
+- TTL enforcement and expiration
+- Deduplication by message ID
+- Storage quotas (max messages, max bytes per recipient)
+- Batch operations
+
+**Client Implementations** (src/client.rs):
+- `RelayClient` for HTTP communication
+- `SimulationClient` for testing
+- Store-and-forward for offline peers (via `StoreForPeer`)
+- Meta messages for presence (Online/Ack/MessageRequest)
+
+**Simulation Framework**:
+- Comprehensive simulation harness
+- Scenario-based testing
+- Metrics tracking (latency, delivery rates)
+
+### ❌ Critical Gaps
+
+#### 1. **Public Messages Not Implemented**
+
+**Current State**: `MessageKind::Public` exists in the enum but is completely unimplemented.
+
+**What's Missing**:
+- No client code sends or receives public messages
+- No relay logic for public message distribution
+- No mechanism to prevent message amplification
+- No peer-level tracking to avoid re-sending messages
+- No time-based cutoff beyond TTL
+
+**Required Behavior**:
+- Any peer can forward a public message to other peers
+- Messages remain signed by original author
+- Deduplication at multiple levels:
+  - Relay level: Already exists (message ID deduplication)
+  - Peer level: Need to track which peers have received which messages
+- Don't re-send to peers who already have the message
+- Stop propagating messages after TTL expires
+- Gossip-style distribution across peer networks
+
+#### 2. **Group Messages Not Implemented**
+
+**Current State**: `MessageKind::FriendGroup` exists, header validation requires `group_id`, but no actual group functionality.
+
+**What's Missing**:
+- No group key management (creation, distribution, rotation)
+- No group membership tracking
+- No group message encryption/decryption
+- No client code to send/receive group messages
+- No group discovery or invitation mechanism
+
+**Required Behavior**:
+- Groups have unique IDs
+- Group members share a symmetric key for message encryption
+- Messages encrypted with group key can be decrypted by all members
+- Group metadata (member list, key version) needs management
+- Messages delivered to all online group members via relay
+
+#### 3. **Signature Verification Not Cryptographically Secure**
+
+**Current Issue**: protocol.rs:176-177 shows that `expected_signature()` is just a SHA256 hash of the header, not an actual Ed25519 signature!
+
+```rust
+let digest = Sha256::digest(&bytes);
+Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest))
+```
+
+This means:
+- Headers can't be verified as coming from the claimed sender
+- Anyone can forge messages
+- Critical for public messages where authenticity is essential
+
+#### 4. **Other Notable Gaps**:
+- No persistent local storage (only in-memory feeds)
+- Attachment storage/retrieval infrastructure missing
+- No peer list management in clients
+- No rate limiting or abuse prevention beyond relay quotas
+
+---
+
+## Implementation Plan
+
+### Phase 1: Foundation Improvements (Prerequisites)
+
+**1.1 Add True Cryptographic Signatures**
+- Add Ed25519 signing to crypto.rs
+- Update `StoredKeypair` to include Ed25519 keys alongside X25519
+- Modify `Header::expected_signature()` to actually sign with sender's private key
+- Update `Header::verify_signature()` to verify against sender's public key
+- Requires: Sender public key lookup in clients
+- Location: `src/crypto.rs`, `src/protocol.rs`
+
+**1.2 Peer Directory for Public Key Lookup**
+- Add peer registry to clients
+- Store: peer_id → public_key mapping
+- Needed for signature verification
+- Location: `src/client.rs`, new `PeerRegistry` struct
+
+### Phase 2: Public Messages Implementation
+
+**2.1 Core Public Message Types** (src/protocol.rs)
+```rust
+pub struct PublicMessageMetadata {
+    pub seen_by: HashSet<String>,  // Track which peers have seen this
+    pub first_seen_at: u64,        // When we first saw this message
+    pub propagation_count: usize,  // How many times we've forwarded
+}
+```
+
+**2.2 Client-Side Public Message Handling** (src/client.rs)
+- Add public message tracking:
+  - `seen_public_messages: HashMap<ContentId, PublicMessageMetadata>`
+  - `public_message_cache: Vec<Envelope>` (recent public messages)
+- Implement `send_public_message()`:
+  - Create envelope with `MessageKind::Public`
+  - Broadcast to all known peers
+  - Track initial distribution
+- Implement `receive_public_message()`:
+  - Verify signature against sender's public key
+  - Check deduplication
+  - Add to local cache
+  - Determine if should forward
+- Implement `forward_public_message()`:
+  - Check TTL hasn't expired
+  - Don't send to peers in `seen_by` set
+  - Update `seen_by` when forwarding
+  - Respect propagation limits
+
+**2.3 Relay Public Message Support** (src/relay.rs)
+- Relay can treat public messages like any other for storage
+- Add optional gossip endpoint for public messages
+- Consider: separate queue for public vs direct messages
+
+**2.4 Propagation Algorithm**
+Strategy: Controlled flooding with tracking
+```
+On receiving public message:
+1. Verify signature
+2. Check if seen (message_id in cache) → skip if yes
+3. Check TTL not expired → skip if expired
+4. Add to local cache with metadata
+5. Deliver to local user
+6. For each peer in peer list:
+   - If peer not in seen_by set:
+     - Forward message to peer
+     - Add peer to seen_by set
+   - Track propagation count
+   - Stop if propagation_count > MAX_HOPS
+```
+
+**2.5 Tests for Public Messages**
+- `tests/public_message_tests.rs`: Unit tests
+- Simulation scenarios with public message propagation
+- Test deduplication across multiple hops
+- Test TTL expiration stops propagation
+- Test seen_by tracking prevents loops
+
+### Phase 3: Group Messages Implementation
+
+**3.1 Group Key Management** (new src/groups.rs)
+```rust
+pub struct GroupInfo {
+    pub group_id: String,
+    pub group_key: [u8; 32],      // Symmetric key for group
+    pub members: HashSet<String>,  // Member peer IDs
+    pub created_at: u64,
+    pub key_version: u32,
+}
+
+pub struct GroupManager {
+    groups: HashMap<String, GroupInfo>,
+}
+
+impl GroupManager {
+    pub fn create_group(&mut self, members: Vec<String>) -> GroupInfo;
+    pub fn add_member(&mut self, group_id: &str, peer_id: &str) -> Result<(), GroupError>;
+    pub fn remove_member(&mut self, group_id: &str, peer_id: &str) -> Result<(), GroupError>;
+    pub fn rotate_key(&mut self, group_id: &str) -> Result<(), GroupError>;
+    pub fn get_group_key(&self, group_id: &str) -> Option<&[u8; 32]>;
+}
+```
+
+**3.2 Group Message Encryption** (src/crypto.rs)
+```rust
+pub fn encrypt_group_payload(
+    plaintext: &[u8],
+    group_key: &[u8; 32],
+    aad: &[u8],
+) -> Result<(Vec<u8>, Vec<u8>), CryptoError>;
+
+pub fn decrypt_group_payload(
+    ciphertext: &[u8],
+    nonce: &[u8],
+    group_key: &[u8; 32],
+    aad: &[u8],
+) -> Result<Vec<u8>, CryptoError>;
+```
+
+**3.3 Group Message Protocol** (src/protocol.rs)
+```rust
+pub fn build_group_message_payload(
+    plaintext: impl AsRef<[u8]>,
+    group_key: &[u8; 32],
+    aad: &[u8],
+) -> Result<Payload, PayloadCryptoError>;
+
+pub fn decrypt_group_message_payload(
+    payload: &Payload,
+    group_key: &[u8; 32],
+    aad: &[u8],
+) -> Result<Vec<u8>, PayloadCryptoError>;
+```
+
+**3.4 Client Group Support** (src/client.rs)
+- Add `GroupManager` to client implementations
+- Implement `create_group()`:
+  - Generate group key
+  - Share key with initial members (encrypted with each member's public key)
+  - Store group locally
+- Implement `send_group_message()`:
+  - Encrypt with group key
+  - Create envelope with `MessageKind::FriendGroup` and `group_id`
+  - Send to all group members (or relay)
+- Implement `receive_group_message()`:
+  - Verify sender is group member
+  - Look up group key
+  - Decrypt payload
+  - Deliver to user
+
+**3.5 Group Key Distribution Protocol**
+Initial approach (simple):
+- Group creator generates symmetric key
+- For each member: wrap key with HPKE (like direct messages)
+- Send `MessageKind::Meta` with group invitation + wrapped key
+- Members store group key locally
+
+Advanced (future):
+- Use a group key agreement protocol (e.g., TreeKEM)
+- Support member addition/removal with forward secrecy
+
+**3.6 Tests for Group Messages**
+- `tests/group_message_tests.rs`: Unit tests
+- Test group creation and key distribution
+- Test message encryption/decryption
+- Test multi-member delivery
+- Simulation scenarios with groups
+
+### Phase 4: Integration & Polish
+
+**4.1 Update Binary Targets**
+- `bin/tenet.rs` (CLI):
+  - Add `send-public <message>` command
+  - Add `create-group <peer1> <peer2> ...` command
+  - Add `send-group <group_id> <message>` command
+  - Add `list-groups` command
+- `bin/tenet-debugger.rs` (TUI):
+  - Add public message sending
+  - Add group creation/management UI
+  - Show public message propagation
+- `bin/tenet-sim.rs`:
+  - Add public message scenarios
+  - Add group message scenarios
+
+**4.2 Enhanced Scenarios**
+Create new scenario files:
+- `scenarios/public_gossip.toml`: Public message propagation
+- `scenarios/group_chat.toml`: Group messaging with multiple groups
+- `scenarios/mixed_traffic.toml`: Direct, public, and group messages
+
+**4.3 Documentation**
+- Update `docs/architecture.md` with public/group message details
+- Add `docs/public_messages.md` - Public message propagation algorithm
+- Add `docs/group_messages.md` - Group management and key distribution
+- Update `CLAUDE.md` with new types and patterns
+
+**4.4 Additional Tests**
+- Integration tests for public + group messages
+- Test message kind transitions
+- Test security boundaries (can't decrypt without keys)
+- Test abuse scenarios (spam, amplification)
+
+---
+
+## Implementation Order & Priority
+
+### High Priority (Core Functionality)
+1. ✅ **Phase 1.1**: True cryptographic signatures (CRITICAL for security)
+2. ✅ **Phase 1.2**: Peer directory for public key lookup
+3. ✅ **Phase 2**: Public messages (requested by user)
+4. ✅ **Phase 3**: Group messages (requested by user)
+
+### Medium Priority (Completeness)
+5. **Phase 4.1**: Update CLI/TUI binaries
+6. **Phase 4.2**: Enhanced scenarios
+7. **Phase 4.4**: Additional tests
+
+### Lower Priority (Nice to Have)
+8. **Phase 4.3**: Documentation updates
+9. Advanced group key management (TreeKEM)
+10. Persistent storage
+11. Attachment handling
+12. Rate limiting & abuse prevention
+
+---
+
+## Key Design Decisions
+
+### Public Messages: Propagation Strategy
+**Decision**: Controlled flooding with per-message seen_by tracking
+- **Pros**: Simple, resilient, natural gossip-style distribution
+- **Cons**: Bandwidth overhead, requires peer-level state
+- **Alternatives considered**: DHT-based routing (too complex), publish-subscribe (requires infrastructure)
+
+### Group Messages: Key Distribution
+**Decision**: Simple symmetric key + HPKE wrapping for initial version
+- **Pros**: Leverages existing crypto, straightforward
+- **Cons**: No forward secrecy on member removal, key rotation is manual
+- **Future**: Upgrade to TreeKEM or similar group key agreement
+
+### Signature Scheme
+**Decision**: Ed25519 for message signatures, separate from X25519 for encryption
+- **Pros**: Industry standard, fast verification, small signatures
+- **Cons**: Need to manage two keypairs per identity (can derive one from the other in future)
+
+### Deduplication Strategy
+**Decision**: Multi-level deduplication
+1. Relay: Message ID dedup with TTL-based expiry
+2. Client: Per-client seen set for all message types
+3. Public messages: Per-message seen_by set for propagation control
+
+---
+
+## Estimated Complexity
+
+| Component | LOC Estimate | Risk | Dependencies |
+|-----------|--------------|------|--------------|
+| Crypto signatures (Phase 1.1) | ~200 | Medium | Ed25519 crate |
+| Peer registry (Phase 1.2) | ~100 | Low | None |
+| Public messages (Phase 2) | ~500 | Medium | Phase 1 |
+| Group messages (Phase 3) | ~800 | High | Phase 1 |
+| Binary updates (Phase 4.1) | ~300 | Low | Phase 2, 3 |
+| Tests | ~600 | Low | All phases |
+| **Total** | **~2,500** | | |
+
+---
+
+## Status Tracking
+
+- [ ] Phase 1.1: Cryptographic Signatures
+- [ ] Phase 1.2: Peer Directory
+- [ ] Phase 2: Public Messages
+- [ ] Phase 3: Group Messages
+- [ ] Phase 4: Integration & Polish

--- a/src/bin/tenet-crypto.rs
+++ b/src/bin/tenet-crypto.rs
@@ -315,14 +315,24 @@ fn import_key(args: &[String]) -> Result<(), Box<dyn Error>> {
     validate_key_len(&private_key_bytes, "private")?;
 
     let id = derive_user_id_from_public_key(&public_key_bytes);
+
+    // Generate Ed25519 signing keys for the imported identity
+    use ed25519_dalek::SigningKey;
+    use rand::rngs::OsRng;
+    let signing_key = SigningKey::generate(&mut OsRng);
+    let verifying_key = signing_key.verifying_key();
+
     let identity = StoredKeypair {
         id,
         public_key_hex,
         private_key_hex,
+        signing_public_key_hex: hex::encode(verifying_key.to_bytes()),
+        signing_private_key_hex: hex::encode(signing_key.to_bytes()),
     };
 
     store_keypair(&identity_path(), &identity)?;
     println!("identity imported: {}", identity.id);
+    println!("note: new Ed25519 signing keys were generated");
     Ok(())
 }
 

--- a/tests/simulation_client_tests.rs
+++ b/tests/simulation_client_tests.rs
@@ -62,6 +62,8 @@ async fn simulation_client_direct_and_store_forward_paths_increment_metrics() {
         ],
     );
     let mut keypairs = HashMap::new();
+    keypairs.insert("node-a".to_string(), generate_keypair());
+    keypairs.insert("node-b".to_string(), generate_keypair());
     keypairs.insert("node-c".to_string(), generate_keypair());
 
     let mut harness = SimulationHarness::new(
@@ -156,6 +158,10 @@ async fn simulation_client_online_handshake_updates_metrics() {
         &[("node-a", "node-b"), ("node-b", "node-a")],
     );
 
+    let mut keypairs = HashMap::new();
+    keypairs.insert("node-a".to_string(), generate_keypair());
+    keypairs.insert("node-b".to_string(), generate_keypair());
+
     let mut harness = SimulationHarness::new(
         base_url,
         clients,
@@ -163,7 +169,7 @@ async fn simulation_client_online_handshake_updates_metrics() {
         true,
         relay_config.ttl.as_secs(),
         MessageEncryption::Plaintext,
-        HashMap::new(),
+        keypairs,
         SimulationTimingConfig {
             base_seconds_per_step: 60.0,
             speed_factor: 1.0,

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
+use tenet::crypto::generate_keypair;
 use tenet::protocol::{build_plaintext_payload, ContentId};
 use tenet::relay::RelayConfig;
 use tenet::simulation::{
@@ -126,6 +127,10 @@ async fn simulation_harness_tracks_online_handshake_metrics() {
     direct_links.insert(("node-a".to_string(), "node-b".to_string()));
     direct_links.insert(("node-b".to_string(), "node-a".to_string()));
 
+    let mut keypairs = HashMap::new();
+    keypairs.insert("node-a".to_string(), generate_keypair());
+    keypairs.insert("node-b".to_string(), generate_keypair());
+
     let mut harness = SimulationHarness::new(
         base_url,
         clients,
@@ -133,7 +138,7 @@ async fn simulation_harness_tracks_online_handshake_metrics() {
         true,
         relay_config.ttl.as_secs(),
         MessageEncryption::Plaintext,
-        Default::default(),
+        keypairs,
         SimulationTimingConfig {
             base_seconds_per_step: 60.0,
             speed_factor: 1.0,
@@ -176,6 +181,10 @@ async fn simulation_harness_delivers_missed_messages_after_handshake() {
     direct_links.insert(("node-a".to_string(), "node-b".to_string()));
     direct_links.insert(("node-b".to_string(), "node-a".to_string()));
 
+    let mut keypairs = HashMap::new();
+    keypairs.insert("node-a".to_string(), generate_keypair());
+    keypairs.insert("node-b".to_string(), generate_keypair());
+
     let mut harness = SimulationHarness::new(
         base_url,
         clients,
@@ -183,7 +192,7 @@ async fn simulation_harness_delivers_missed_messages_after_handshake() {
         true,
         relay_config.ttl.as_secs(),
         MessageEncryption::Plaintext,
-        Default::default(),
+        keypairs,
         SimulationTimingConfig {
             base_seconds_per_step: 60.0,
             speed_factor: 1.0,
@@ -241,6 +250,10 @@ async fn simulation_harness_applies_dynamic_updates() {
     direct_links.insert(("node-a".to_string(), "node-b".to_string()));
     direct_links.insert(("node-b".to_string(), "node-a".to_string()));
 
+    let mut keypairs = HashMap::new();
+    keypairs.insert("node-a".to_string(), generate_keypair());
+    keypairs.insert("node-b".to_string(), generate_keypair());
+
     let mut harness = SimulationHarness::new(
         base_url,
         clients,
@@ -248,7 +261,7 @@ async fn simulation_harness_applies_dynamic_updates() {
         true,
         relay_config.ttl.as_secs(),
         MessageEncryption::Plaintext,
-        Default::default(),
+        keypairs,
         SimulationTimingConfig {
             base_seconds_per_step: 60.0,
             speed_factor: 1.0,


### PR DESCRIPTION
## Summary

This PR introduces cryptographically secure Ed25519 message signatures to replace the previous insecure SHA256-based approach, and adds a comprehensive implementation plan for public and group messaging features.

## Key Changes

### Cryptographic Improvements
- **Added Ed25519 signing**: Implemented `sign_message()` and `verify_signature()` functions in `crypto.rs` using the `ed25519-dalek` crate
- **Updated keypair structure**: `StoredKeypair` now includes Ed25519 signing keys (`signing_public_key_hex` and `signing_private_key_hex`) alongside existing X25519 encryption keys
- **Secure header signatures**: Changed `Header::expected_signature()` to `Header::compute_signature()` which now uses actual Ed25519 signatures instead of SHA256 hashes
- **Signature verification**: Updated `Header::verify_signature()` to accept the sender's public key and cryptographically verify signatures

### Client Updates
- **Peer registry**: Added `known_peers` map to `RelayClient` to track peer signing public keys via `add_peer()` method
- **Signature verification in message decoding**: Updated `decode_envelope()` to verify signatures using the sender's stored public key
- **Signing on message creation**: All envelope creation now requires passing the sender's signing private key

### Test Updates
- Updated all protocol tests to use actual keypairs and verify signatures cryptographically
- Added comprehensive signature tests: valid signatures, invalid signatures, wrong public key rejection
- Updated simulation tests to properly initialize keypairs for all nodes

### Documentation
- Added `docs/PLAN.md`: Comprehensive 373-line implementation plan covering:
  - Current state assessment of the codebase
  - Critical gaps (public messages, group messages, signature security)
  - Detailed 4-phase implementation plan with code examples
  - Design decisions and complexity estimates
  - Status tracking checklist

## Implementation Details

The signature scheme now uses:
- **Ed25519** for message authentication (fast verification, small signatures)
- **X25519** for encryption (unchanged, separate from signing)
- **Per-message signing**: Each envelope header is signed with the sender's Ed25519 private key
- **Verification requirement**: Recipients must know the sender's public key to verify signatures

The plan document outlines the path forward for:
1. **Public messages**: Controlled flooding with per-message deduplication tracking
2. **Group messages**: Symmetric key distribution with HPKE wrapping
3. **Integration**: CLI/TUI updates and comprehensive test coverage

## Dependencies Added
- `ed25519-dalek` (v2.1) for Ed25519 signing and verification
- `base64ct` (v1.8.3) as transitive dependency

## Breaking Changes
- `Header::verify_signature()` now requires the sender's public key as a parameter
- `build_envelope_from_payload()` and `build_plaintext_envelope()` now require `signing_private_key_hex` parameter
- Existing stored keypairs will need migration to include Ed25519 keys (handled in `tenet-crypto` binary)

https://claude.ai/code/session_016WdApvpqmTom8qEPoZKC4c