### PR TITLE
Implement peer directory for public key lookup (Phase 1.2)

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -304,10 +304,10 @@ Create new scenario files:
 ## Implementation Order & Priority
 
 ### High Priority (Core Functionality)
-1. ✅ **Phase 1.1**: True cryptographic signatures (CRITICAL for security)
-2. ✅ **Phase 1.2**: Peer directory for public key lookup
-3. ✅ **Phase 2**: Public messages (requested by user)
-4. ✅ **Phase 3**: Group messages (requested by user)
+1. ✅ **Phase 1.1**: True cryptographic signatures (CRITICAL for security) - **COMPLETE**
+2. ✅ **Phase 1.2**: Peer directory for public key lookup - **COMPLETE**
+3. **Phase 2**: Public messages (requested by user)
+4. **Phase 3**: Group messages (requested by user)
 
 ### Medium Priority (Completeness)
 5. **Phase 4.1**: Update CLI/TUI binaries
@@ -366,8 +366,8 @@ Create new scenario files:
 
 ## Status Tracking
 
-- [ ] Phase 1.1: Cryptographic Signatures
-- [ ] Phase 1.2: Peer Directory
+- [x] Phase 1.1: Cryptographic Signatures
+- [x] Phase 1.2: Peer Directory
 - [ ] Phase 2: Public Messages
 - [ ] Phase 3: Group Messages
 - [ ] Phase 4: Integration & Polish


### PR DESCRIPTION
## Summary
Implements Phase 1.2 of the project roadmap by introducing a comprehensive peer directory system for managing known peers and their public keys. This enables clients to look up and verify cryptographic keys for other peers in the network.

## Key Changes

- **New `PeerRegistry` struct**: A dedicated registry for managing peer information with support for both signing and encryption public keys
  - Provides methods for adding, removing, and querying peers
  - Stores peer metadata including timestamps
  - Fully serializable/deserializable for persistence

- **Enhanced `PeerInfo` struct**: Represents a known peer with:
  - Peer ID
  - Signing public key (required)
  - Encryption public key (optional)
  - Timestamp of when peer was added

- **Updated `RelayClient`**: Replaced simple `HashMap` with full `PeerRegistry`
  - Added `add_peer_with_encryption()` for storing both key types
  - Added `remove_peer()`, `get_peer()`, `list_peers()` methods
  - Updated signature verification to use registry's `get_signing_key()`

- **Updated `SimulationClient`**: Added identical peer management interface as `RelayClient`
  - Ensures consistent API across both client types
  - Enables peer directory functionality in simulations

- **Comprehensive test suite**: Added 11 new tests covering:
  - Registry creation and basic operations
  - Adding/removing peers
  - Key retrieval (signing and encryption)
  - Peer listing and enumeration
  - Peer updates
  - Integration with both client types

- **Documentation updates**: Marked Phase 1.1 and 1.2 as complete in PLAN.md

## Implementation Details

The `PeerRegistry` uses a `HashMap` internally for O(1) lookups while providing a clean, type-safe API. The registry automatically timestamps peer additions for audit purposes. Both client types now delegate peer management to their respective registry instances, maintaining a single source of truth for peer information.

This implementation is foundational for Phase 2 (public messages) and Phase 3 (group messages), as it provides the infrastructure needed to verify signatures and manage encryption keys across the network.

https://claude.ai/code/session_01LBCdS4J6QDyaST8YMdrUAE