### PR TITLE
Implement Phase 2: Public Messages

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -306,7 +306,7 @@ Create new scenario files:
 ### High Priority (Core Functionality)
 1. ✅ **Phase 1.1**: True cryptographic signatures (CRITICAL for security) - **COMPLETE**
 2. ✅ **Phase 1.2**: Peer directory for public key lookup - **COMPLETE**
-3. **Phase 2**: Public messages (requested by user)
+3. ✅ **Phase 2**: Public messages (requested by user) - **COMPLETE**
 4. **Phase 3**: Group messages (requested by user)
 
 ### Medium Priority (Completeness)
@@ -368,6 +368,6 @@ Create new scenario files:
 
 - [x] Phase 1.1: Cryptographic Signatures
 - [x] Phase 1.2: Peer Directory
-- [ ] Phase 2: Public Messages
+- [x] Phase 2: Public Messages
 - [ ] Phase 3: Group Messages
 - [ ] Phase 4: Integration & Polish


### PR DESCRIPTION
This commit implements Phase 2 of the Tenet project plan, adding full support for public message propagation across the peer-to-peer network.

Changes:

**Core Types and Structures:**
- Added PublicMessageMetadata struct for tracking message propagation
  - Tracks which peers have seen each message (seen_by set)
  - Records first_seen_at timestamp
  - Counts propagation_count to limit flooding
  - Includes should_forward() method to enforce MAX_PUBLIC_MESSAGE_HOPS limit
- Added MAX_PUBLIC_MESSAGE_HOPS constant (default: 10 hops)

**RelayClient Updates:**
- Added public_message_cache: Vec<Envelope> for storing recent public messages
- Added public_message_metadata: HashMap<ContentId, PublicMessageMetadata>
- Implemented send_public_message() for broadcasting public messages
  - Creates plaintext envelopes with recipient_id = "*" (broadcast indicator)
  - Posts to relay and forwards to all known peers
  - Initializes metadata tracking
- Implemented receive_public_message() for processing incoming public messages
  - Verifies signature against sender's public key from PeerRegistry
  - Checks for deduplication (already seen messages)
  - Validates TTL to prevent propagating expired messages
  - Adds message to local feed and cache
  - Automatically forwards to peers if propagation limit not reached
- Implemented forward_public_message_to_peers() helper
  - Filters peers to avoid loops (self, original sender, already seen)
  - Updates seen_by tracking
  - Increments propagation count
  - Best-effort posting to relay

**SimulationClient Updates:**
- Added same public_message_cache and public_message_metadata fields
- Implemented send_public_message() for simulation context
  - Takes step and ClientContext parameters
  - Creates signed public message envelopes
  - Logs actions for debugging
- Implemented receive_public_message() for simulation
  - Verifies signatures using ClientContext keypairs
  - Checks TTL against current step
  - Handles deduplication
  - Returns bool indicating success
- Implemented forward_public_message() for controlled forwarding
  - Takes explicit peer_ids list
  - Filters out self and original sender
  - Updates metadata and returns list of peers forwarded to

**Propagation Algorithm:**
The implementation follows a controlled flooding strategy:
1. Verify message signature
2. Check if already seen (deduplicate)
3. Check TTL not expired
4. Add to local cache with metadata
5. Deliver to local user
6. Forward to known peers not in seen_by set
7. Stop if propagation_count >= MAX_PUBLIC_MESSAGE_HOPS

**Comprehensive Testing:**
- test_public_message_metadata_new(): Basic metadata creation
- test_public_message_metadata_mark_seen(): Seen tracking
- test_public_message_metadata_propagation_limit(): Hop limit enforcement
- test_relay_client_send_public_message(): RelayClient broadcasting
- test_relay_client_receive_public_message_unknown_sender(): Unknown sender rejection
- test_simulation_client_public_message_dedup(): Deduplication verification
- test_simulation_client_public_message_ttl_expiration(): TTL enforcement
- test_simulation_client_forward_public_message(): Forward filtering logic

**Documentation:**
- Updated docs/PLAN.md to mark Phase 2 as COMPLETE

All tests passing (27 tests total, including 8 new public message tests).

https://claude.ai/code/session_cumfu