### PR TITLE
Add support for public and group messaging in simulation

### DIFF
--- a/scenarios/group_messages_test.toml
+++ b/scenarios/group_messages_test.toml
@@ -1,0 +1,87 @@
+# Test scenario for group messages
+# This scenario tests group message functionality with nodes organized into groups.
+
+[simulation]
+node_ids = ["peer-1", "peer-2", "peer-3", "peer-4", "peer-5", "peer-6", "peer-7", "peer-8"]
+steps = 40
+seed = 456
+
+[simulation.simulated_time]
+seconds_per_step = 300
+default_speed_factor = 1.0
+
+[simulation.friends_per_node]
+type = "uniform"
+min = 3
+max = 5
+
+[simulation.post_frequency]
+type = "poisson"
+lambda_per_hour = 6.0
+
+# Default message type weights - mixed messaging
+[simulation.message_type_weights]
+direct = 0.4
+public = 0.2
+group = 0.4
+
+# Group configuration
+[simulation.groups]
+count = 3
+
+[simulation.groups.size_distribution]
+type = "uniform"
+min = 3
+max = 5
+
+[simulation.groups.memberships_per_node]
+type = "uniform"
+min = 1
+max = 2
+
+# Cohort that focuses on group messaging
+[[simulation.cohorts]]
+name = "group-chatters"
+type = "always_online"
+share = 0.4
+[simulation.cohorts.message_type_weights]
+direct = 0.2
+public = 0.1
+group = 0.7
+
+# Cohort that uses a mix of all message types
+[[simulation.cohorts]]
+name = "mixed-users"
+type = "diurnal"
+share = 0.4
+online_probability = 0.7
+timezone_offset_hours = 0
+hourly_weights = [0.2, 0.15, 0.1, 0.1, 0.15, 0.3, 0.5, 0.7, 0.9, 1.0, 1.0, 0.95, 0.9, 0.8, 0.75, 0.8, 0.9, 1.0, 0.95, 0.8, 0.6, 0.45, 0.3, 0.25]
+[simulation.cohorts.message_type_weights]
+direct = 0.5
+public = 0.2
+group = 0.3
+
+# Cohort that primarily uses direct messages
+[[simulation.cohorts]]
+name = "private-messengers"
+type = "rarely_online"
+share = 0.2
+online_probability = 0.3
+[simulation.cohorts.message_type_weights]
+direct = 0.9
+public = 0.05
+group = 0.05
+
+[simulation.message_size_distribution]
+type = "uniform"
+min = 30
+max = 150
+
+[relay]
+ttl_seconds = 2400
+max_messages = 1000
+max_bytes = 2097152
+retry_backoff_seconds = [1, 2, 4]
+peer_log_window_seconds = 30
+peer_log_interval_seconds = 10

--- a/scenarios/public_messages_test.toml
+++ b/scenarios/public_messages_test.toml
@@ -1,0 +1,61 @@
+# Test scenario for public messages
+# This scenario tests public message broadcasting with different cohorts
+# having different message type probabilities.
+
+[simulation]
+node_ids = ["peer-1", "peer-2", "peer-3", "peer-4", "peer-5", "peer-6"]
+steps = 30
+seed = 123
+
+[simulation.simulated_time]
+seconds_per_step = 300
+default_speed_factor = 1.0
+
+[simulation.friends_per_node]
+type = "uniform"
+min = 3
+max = 5
+
+[simulation.post_frequency]
+type = "poisson"
+lambda_per_hour = 5.0
+
+# Default message type weights for the simulation (used when cohort doesn't specify)
+[simulation.message_type_weights]
+direct = 0.5
+public = 0.5
+group = 0.0
+
+# Cohort that posts mostly public messages
+[[simulation.cohorts]]
+name = "broadcasters"
+type = "always_online"
+share = 0.5
+[simulation.cohorts.message_type_weights]
+direct = 0.2
+public = 0.8
+group = 0.0
+
+# Cohort that posts mostly direct messages
+[[simulation.cohorts]]
+name = "direct-messengers"
+type = "rarely_online"
+share = 0.5
+online_probability = 0.6
+[simulation.cohorts.message_type_weights]
+direct = 0.8
+public = 0.2
+group = 0.0
+
+[simulation.message_size_distribution]
+type = "uniform"
+min = 20
+max = 100
+
+[relay]
+ttl_seconds = 1800
+max_messages = 500
+max_bytes = 1048576
+retry_backoff_seconds = [1, 2, 4]
+peer_log_window_seconds = 30
+peer_log_interval_seconds = 10

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -16,7 +16,8 @@ pub mod scenario;
 
 pub use crate::client::SimulationClient;
 pub use config::{
-    ClusteringConfig, FriendsPerNode, MessageEncryption, MessageSizeDistribution,
+    ClusteringConfig, FriendsPerNode, GroupMembershipsPerNode, GroupSizeDistribution, GroupsConfig,
+    MessageEncryption, MessageSizeDistribution, MessageType, MessageTypeWeights,
     OnlineAvailability, OnlineCohortDefinition, PostFrequency, RelayConfigToml,
     SimulatedTimeConfig, SimulationConfig, SimulationScenarioConfig, SimulationTimingConfig,
 };

--- a/tests/simulation_client_tests.rs
+++ b/tests/simulation_client_tests.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use tenet::client::{ClientLogEvent, ClientLogSink};
 use tenet::crypto::generate_keypair;
-use tenet::protocol::{build_plaintext_payload, ContentId};
+use tenet::protocol::{build_plaintext_payload, ContentId, MessageKind};
 use tenet::relay::RelayConfig;
 use tenet::simulation::{
     start_relay, MessageEncryption, PlannedSend, SimMessage, SimulationClient, SimulationHarness,
@@ -97,6 +97,8 @@ async fn simulation_client_direct_and_store_forward_paths_increment_metrics() {
                 recipient: "node-b".to_string(),
                 body: "store-forward".to_string(),
                 payload,
+                message_kind: MessageKind::Direct,
+                group_id: None,
             },
         },
         PlannedSend {
@@ -107,6 +109,8 @@ async fn simulation_client_direct_and_store_forward_paths_increment_metrics() {
                 recipient: "node-b".to_string(),
                 body: "direct".to_string(),
                 payload: direct_payload,
+                message_kind: MessageKind::Direct,
+                group_id: None,
             },
         },
     ];
@@ -286,4 +290,3 @@ fn test_group_creation_and_management() {
     let updated = client.get_group("group-1").expect("get updated group");
     assert!(!updated.is_member("node-c"));
 }
-

--- a/tests/simulation_harness_tests.rs
+++ b/tests/simulation_harness_tests.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use tenet::crypto::generate_keypair;
-use tenet::protocol::{build_plaintext_payload, ContentId};
+use tenet::protocol::{build_plaintext_payload, ContentId, MessageKind};
 use tenet::relay::RelayConfig;
 use tenet::simulation::{
     build_simulation_inputs, start_relay, FriendsPerNode, MessageEncryption,
@@ -48,6 +48,8 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
         cohorts: Vec::new(),
         message_size_distribution: MessageSizeDistribution::Uniform { min: 8, max: 32 },
         encryption: Some(MessageEncryption::Plaintext),
+        groups: None,
+        message_type_weights: None,
         seed: 42,
     };
 
@@ -78,6 +80,8 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
             recipient: "node-b".to_string(),
             body: "relay me".to_string(),
             payload,
+            message_kind: MessageKind::Direct,
+            group_id: None,
         },
     });
     let payload = build_plaintext_payload("direct and relay", b"message-c");
@@ -91,6 +95,8 @@ async fn simulation_harness_routes_relay_and_direct_with_dedup() {
             recipient: "node-b".to_string(),
             body: "direct and relay".to_string(),
             payload,
+            message_kind: MessageKind::Direct,
+            group_id: None,
         },
     });
 
@@ -213,6 +219,8 @@ async fn simulation_harness_delivers_missed_messages_after_handshake() {
             recipient: "node-a".to_string(),
             body: "missed".to_string(),
             payload,
+            message_kind: MessageKind::Direct,
+            group_id: None,
         },
     }];
 


### PR DESCRIPTION
## Summary
This PR extends the simulation framework to support three message types: direct, public, and group messaging. Previously, the simulation only supported direct messages. Now users can configure message type distributions per cohort and per simulation, and the system properly routes and handles each message type differently.

## Key Changes

- **Message Type Configuration**: Added `MessageTypeWeights` struct to configure the probability distribution of message types (direct, public, group) at both the simulation level and per-cohort level. Weights are normalized at runtime to sum to 1.0.

- **Group Management**: Implemented group creation and membership assignment based on configurable distributions:
  - Groups can be sized uniformly or as a fraction of total nodes
  - Node membership can be fixed or uniformly distributed across a range
  - Nodes are automatically assigned to groups during scenario setup

- **Message Routing Logic**: Updated `SimulationClient::send_messages()` to handle three distinct message types:
  - **Direct messages**: Sent to specific recipients with store-forward support for offline nodes
  - **Public messages**: Broadcast to all nodes (recipient set to "*"), always plaintext
  - **Group messages**: Sent to group members with group ID tracking

- **Simulation Planning**: Enhanced `build_planned_sends()` to sample message types based on weights and generate appropriate messages with correct metadata (`message_kind` and `group_id` fields).

- **Test Scenarios**: Added two new TOML configuration files:
  - `public_messages_test.toml`: Tests public message broadcasting with different cohorts
  - `group_messages_test.toml`: Tests group messaging with 3 groups and mixed user cohorts

- **Test Updates**: Updated existing tests to include the new `message_kind` and `group_id` fields in `SimMessage` structures.

## Implementation Details

- Message type sampling uses a cumulative distribution approach: direct messages are sampled first, then public, then group as fallback
- Group messages fall back to direct messages if a node has no group memberships
- Public messages are always plaintext (no encryption)
- The `NodeCohortAssignment` struct tracks which cohort each node belongs to and its message type weights
- Group membership is stored in a `node_groups` HashMap for efficient lookup during message planning

https://claude.ai/code/session_01SQGPefAYfwzerdxoR6u6yz