### PR TITLE
Fix group_id parameter position in FriendGroup envelope building

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2047,12 +2047,12 @@ impl Client for SimulationClient {
                     let envelope = match build_envelope_from_payload(
                         message.sender.clone(),
                         message.recipient.clone(), // Group ID as recipient for routing
-                        group_id.clone(),
-                        None,
+                        None,                      // store_for - not used for group messages
+                        None,                      // storage_peer_id - not used for group messages
                         timestamp,
                         context.ttl_seconds,
                         MessageKind::FriendGroup,
-                        None,
+                        group_id,                  // group_id - required for FriendGroup
                         message.payload.clone(),
                         &sender_keypair.signing_private_key_hex,
                     ) {


### PR DESCRIPTION
The group_id was being passed as the store_for parameter instead of the group_id parameter in build_envelope_from_payload. This caused the header validation to fail silently and skip all FriendGroup messages.

https://claude.ai/code/session_01SQGPefAYfwzerdxoR6u6yz