### PR TITLE
Add graceful shutdown for peer log task and relay config override

### DIFF
--- a/src/bin/simulation.rs
+++ b/src/bin/simulation.rs
@@ -106,6 +106,7 @@ async fn run_with_tui(
         tenet::simulation::run_event_based_scenario_with_tui(
             scenario_for_task,
             control_rx,
+            relay_config,
             |update| {
                 let _ = tx.send(update);
             },


### PR DESCRIPTION
## Summary
This PR adds graceful shutdown support for the peer log task and enables relay configuration overrides in the TUI simulation runner. These changes improve resource cleanup and provide better control over relay behavior during simulations.

## Key Changes
- **Peer log task shutdown**: Modified `start_peer_log_task()` to accept a shutdown receiver, allowing the task to be gracefully terminated when the relay server shuts down. The task now uses `tokio::select!` to listen for either the periodic tick or shutdown signal.
- **Relay config override**: Added `relay_config_override` parameter to `run_event_based_scenario_with_tui()` to allow callers to provide custom relay configuration instead of always using the scenario's default configuration.
- **Shutdown signal propagation**: Updated `start_relay()` to create and manage a shutdown channel for the peer log task, ensuring it terminates cleanly after the server stops.
- **Simulation harness integration**: Modified the TUI simulation runner to pass the relay configuration through to the scenario runner.

## Implementation Details
- The peer log task now properly handles cancellation via a oneshot channel, preventing resource leaks when simulations complete.
- The shutdown signal is sent after the server finishes, ensuring all pending log operations complete before termination.
- The relay config override enables more flexible test scenarios where relay behavior can be customized independently of the scenario definition.

https://claude.ai/code/session_01TrjygWavncxgxMWU1FPmJh