### PR TITLE
Fix TUI responsiveness and simulation speed

### DIFF
--- a/src/simulation/scenario.rs
+++ b/src/simulation/scenario.rs
@@ -161,8 +161,8 @@ where
         (steps as u64 * seconds_per_step) as u64
     }) as f64;
 
-    // Default to real-time mode for TUI
-    let time_control_mode = TimeControlMode::RealTime { speed_factor: 1.0 };
+    // Default to fast-forward mode for TUI (users can adjust speed with controls)
+    let time_control_mode = TimeControlMode::FastForward;
     let clock = SimulationClock::new(time_control_mode);
 
     let network_conditions = NetworkConditions::default();


### PR DESCRIPTION
This commit fixes two critical issues that made the TUI unusable:

1. **Keyboard input unresponsive**: Keyboard commands appeared to do nothing because render() after key press only happened when last_update.is_some(). Since last_update started as None, nothing would render until the first simulation update arrived. Fixed by:
   - Replacing Option<SimulationStepUpdate> with a concrete SimulationStepUpdate
   - Always having a valid current_update to render
   - Removing conditional rendering - always render after any input

2. **Simulation taking hours to run**: The TUI was hardcoded to RealTime mode at 1.0x speed. For a scenario simulating 5 hours (18,000 seconds), this would take 5 real hours to complete! Fixed by:
   - Changed default time control mode to FastForward
   - FastForward runs as fast as possible without artificial delays
   - Users can still adjust speed with keyboard controls (F, R, +/-)

Additional improvements:
- Removed unused last_update variable
- Simplified state management by always having a valid update
- All rendering code paths now work consistently

The simulation now:
- Starts immediately with a visible UI
- Runs at maximum speed by default
- Responds instantly to keyboard input
- Updates progress continuously as simulation advances
- Allows users to adjust speed with F (fast-forward), R (real-time), +/- keys

https://claude.ai/code/session_01TrjygWavncxgxMWU1FPmJh