### PR TITLE
Fix event loop exit handling to drain pending progress updates

### DIFF
--- a/src/bin/simulation.rs
+++ b/src/bin/simulation.rs
@@ -216,9 +216,9 @@ async fn run_with_tui(
                         base_seconds_per_step,
                     )
                     .map_err(|err| err.to_string())?;
-                } else if rx.is_closed() {
-                    break;
                 }
+                // Don't break here - let the main rx.recv() handle loop exit
+                // to ensure we drain any pending progress updates
             }
             relay_log_line = relay_log_rx.recv() => {
                 if let Some(line) = relay_log_line {
@@ -236,9 +236,9 @@ async fn run_with_tui(
                         base_seconds_per_step,
                     )
                     .map_err(|err| err.to_string())?;
-                } else if rx.is_closed() {
-                    break;
                 }
+                // Don't break here - let the main rx.recv() handle loop exit
+                // to ensure we drain any pending progress updates
             }
             input_event = input_rx.recv() => {
                 if let Some(Event::Key(key)) = input_event {


### PR DESCRIPTION
## Summary
Refactored the TUI event loop to prevent premature exit when channels close, ensuring all pending progress updates are properly drained before the loop terminates.

## Changes
- Removed early `break` statements that triggered when `rx` channel was closed in the `relay_log_rx` and `input_rx` match arms
- Consolidated channel closure handling to the main `rx.recv()` branch, which is the authoritative exit point for the event loop
- Added clarifying comments explaining the rationale for deferring loop exit

## Implementation Details
Previously, the event loop would break immediately upon detecting a closed channel in any of the select branches. This could cause the loop to exit before processing all pending messages from the main `rx` channel, potentially losing progress updates.

By moving all closure detection to the primary `rx.recv()` branch, we ensure that:
1. The loop only exits when the main channel is exhausted
2. Any pending progress updates queued in `rx` are fully processed before termination
3. The event loop has a single, clear exit point

This is a defensive fix that improves reliability of progress reporting in the simulation TUI.

https://claude.ai/code/session_01XkRNteA1684adRDNJQEn1y