### PR TITLE
Add shutdown signal support to peer log task

### DIFF
--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -23,7 +23,8 @@ async fn main() {
     };
 
     let state = RelayState::new(config);
-    state.start_peer_log_task();
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    state.start_peer_log_task(shutdown_rx);
     let app = app(state);
 
     let bind = env::var("TENET_RELAY_BIND").unwrap_or_else(|_| "0.0.0.0:8080".to_string());


### PR DESCRIPTION
## Summary
Modified the peer log task initialization to accept a shutdown signal channel, enabling graceful shutdown capabilities for the peer logging functionality.

## Changes
- Created a `tokio::sync::oneshot` channel to handle shutdown signaling
- Updated `start_peer_log_task()` call to pass the shutdown receiver as a parameter
- The shutdown transmitter is created but currently unused (marked with `_shutdown_tx`), allowing for future shutdown trigger implementation

## Implementation Details
This change introduces the infrastructure for graceful shutdown of the peer log task. The oneshot channel pattern allows the task to be notified when shutdown is requested, enabling clean termination and resource cleanup. The unused transmitter suggests this is a preparatory change for shutdown logic that will be implemented in subsequent commits.

https://claude.ai/code/session_01PztwgQQfkXo3fJ4NPVPuA4