### PR TITLE
Implement Phase 6: Public Posting with post detail view

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,12 +16,12 @@ fn build_web_assets() {
     }
 
     // Read source files
-    let html_template = fs::read_to_string(src_dir.join("index.html"))
-        .expect("Failed to read web/src/index.html");
-    let styles = fs::read_to_string(src_dir.join("styles.css"))
-        .expect("Failed to read web/src/styles.css");
-    let scripts = fs::read_to_string(src_dir.join("app.js"))
-        .expect("Failed to read web/src/app.js");
+    let html_template =
+        fs::read_to_string(src_dir.join("index.html")).expect("Failed to read web/src/index.html");
+    let styles =
+        fs::read_to_string(src_dir.join("styles.css")).expect("Failed to read web/src/styles.css");
+    let scripts =
+        fs::read_to_string(src_dir.join("app.js")).expect("Failed to read web/src/app.js");
 
     // Replace placeholders
     let output = html_template
@@ -29,8 +29,7 @@ fn build_web_assets() {
         .replace("{{SCRIPTS}}", &scripts);
 
     // Write output
-    fs::write(dist_dir.join("index.html"), output)
-        .expect("Failed to write web/dist/index.html");
+    fs::write(dist_dir.join("index.html"), output).expect("Failed to write web/dist/index.html");
 
     println!("cargo:rerun-if-changed=web/src/index.html");
     println!("cargo:rerun-if-changed=web/src/styles.css");

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -344,7 +344,7 @@ GET    /api/conversations/:peer_id       -- messages with a specific peer
 
 ---
 
-## Phase 6 — Public Posting
+## Phase 6 — Public Posting ✅ COMPLETE
 
 **Goal**: Compose and view public posts with a clear distinct presentation.
 

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -391,6 +391,58 @@ body {
     font-weight: 500;
 }
 
+/* Post detail view */
+.post-detail {
+    display: none;
+}
+.post-detail.visible { display: block; }
+.post-detail-back {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+}
+.post-detail-back button {
+    background: #2a2d37;
+    border: none;
+    color: #aaa;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+.post-detail-back button:hover { background: #3a3d47; color: #ddd; }
+.post-detail-content {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 1.5rem;
+}
+.post-detail-content .post-sender {
+    font-size: 0.9rem;
+    color: #aaa;
+    margin-bottom: 0.5rem;
+}
+.post-detail-content .post-sender.self { color: #5566cc; }
+.post-detail-content .post-time {
+    font-size: 0.8rem;
+    color: #666;
+    margin-bottom: 1rem;
+}
+.post-detail-content .post-body {
+    font-size: 1rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.message.clickable {
+    cursor: pointer;
+}
+.message.clickable:hover {
+    border-color: #5566cc;
+}
+
 /* Toast notification */
 .toast {
     position: fixed;
@@ -485,6 +537,14 @@ body {
                 </div>
             </div>
 
+            <!-- Post detail -->
+            <div id="post-detail" class="post-detail">
+                <div class="post-detail-back">
+                    <button onclick="backToPublicFeed()">&#8592; Back to Feed</button>
+                </div>
+                <div id="post-detail-content"></div>
+            </div>
+
             <!-- Load more / empty -->
             <div id="load-more" class="load-more" style="display:none;">
                 <button onclick="loadMore()">Load older messages</button>
@@ -505,7 +565,7 @@ body {
 // ---------------------------------------------------------------------------
 let myPeerId = '';
 let currentFilter = '';
-let currentView = 'timeline'; // 'timeline', 'conversations', 'conversation-detail'
+let currentView = 'timeline'; // 'timeline', 'conversations', 'conversation-detail', 'post-detail'
 let messages = [];
 let oldestTimestamp = null;
 let ws = null;
@@ -514,6 +574,7 @@ let conversations = [];
 let currentConversationPeerId = null;
 let conversationMessages = [];
 let conversationOldestTimestamp = null;
+let currentPostId = null;
 const PAGE_SIZE = 50;
 
 // ---------------------------------------------------------------------------
@@ -575,7 +636,14 @@ function renderMessage(m) {
     const unreadClass = m.is_read ? '' : ' unread';
     const kindClass = m.message_kind || 'direct';
 
-    return `<div class="message${unreadClass}" data-id="${m.message_id}" onclick="markRead('${m.message_id}')">
+    // Make public messages clickable to view detail
+    const isPublic = m.message_kind === 'public';
+    const clickableClass = isPublic ? ' clickable' : '';
+    const onclick = isPublic
+        ? `onclick="showPostDetail('${m.message_id}')"`
+        : `onclick="markRead('${m.message_id}')"`;
+
+    return `<div class="message${unreadClass}${clickableClass}" data-id="${m.message_id}" ${onclick}>
         <div class="msg-header">
             <span class="msg-badge ${kindClass}">${kindClass}</span>
             <span class="${senderClass}" title="${m.sender_id}">${senderLabel}</span>
@@ -663,6 +731,7 @@ function showTimelineView() {
     document.getElementById('empty-state').style.display = 'none';
     document.getElementById('conversations-list').style.display = 'none';
     document.getElementById('conversation-detail').classList.remove('visible');
+    document.getElementById('post-detail').classList.remove('visible');
     document.getElementById('compose-kind').value = currentFilter || 'public';
     updateComposeOptions();
 }
@@ -673,6 +742,7 @@ function showConversationsView() {
     document.getElementById('empty-state').style.display = 'none';
     document.getElementById('conversations-list').style.display = '';
     document.getElementById('conversation-detail').classList.remove('visible');
+    document.getElementById('post-detail').classList.remove('visible');
     loadConversations();
 }
 
@@ -684,6 +754,7 @@ function showConversationDetail(peerId) {
     document.getElementById('load-more').style.display = 'none';
     document.getElementById('conversations-list').style.display = 'none';
     document.getElementById('conversation-detail').classList.add('visible');
+    document.getElementById('post-detail').classList.remove('visible');
 
     const peer = peers.find(p => p.peer_id === peerId);
     const peerName = peer?.display_name || peerId.substring(0, 12) + '...';
@@ -698,6 +769,60 @@ function backToConversations() {
     currentView = 'conversations';
     currentConversationPeerId = null;
     showConversationsView();
+}
+
+// ---------------------------------------------------------------------------
+// Post detail view
+// ---------------------------------------------------------------------------
+async function showPostDetail(messageId) {
+    currentView = 'post-detail';
+    currentPostId = messageId;
+
+    document.getElementById('timeline').style.display = 'none';
+    document.getElementById('load-more').style.display = 'none';
+    document.getElementById('conversations-list').style.display = 'none';
+    document.getElementById('conversation-detail').classList.remove('visible');
+    document.getElementById('post-detail').classList.add('visible');
+
+    try {
+        const post = await apiGet(`/api/messages/${messageId}`);
+        renderPostDetail(post);
+        // Mark as read when viewing
+        if (!post.is_read) {
+            await apiPost(`/api/messages/${messageId}/read`, {});
+        }
+    } catch (e) {
+        showToast('Failed to load post');
+        console.error(e);
+    }
+}
+
+function renderPostDetail(post) {
+    const el = document.getElementById('post-detail-content');
+    const isSelf = post.sender_id === myPeerId;
+    const senderLabel = isSelf ? 'You' : post.sender_id.substring(0, 12) + '...';
+    const senderClass = isSelf ? 'post-sender self' : 'post-sender';
+    const timestamp = new Date(post.timestamp * 1000).toLocaleString();
+
+    el.innerHTML = `
+        <div class="${senderClass}" title="${post.sender_id}">${escapeHtml(senderLabel)}</div>
+        <div class="post-time">${timestamp}</div>
+        <div class="post-body">${escapeHtml(post.body || '')}</div>
+    `;
+}
+
+function backToPublicFeed() {
+    currentView = 'timeline';
+    currentPostId = null;
+    // Set filter to public to return to public feed
+    currentFilter = 'public';
+
+    // Update active filter button
+    document.querySelectorAll('.filters button').forEach(b => b.classList.remove('active'));
+    document.querySelector('.filters button[data-kind="public"]').classList.add('active');
+
+    showTimelineView();
+    loadMessages(false);
 }
 
 function updateComposeOptions() {

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -81,6 +81,14 @@
                 </div>
             </div>
 
+            <!-- Post detail -->
+            <div id="post-detail" class="post-detail">
+                <div class="post-detail-back">
+                    <button onclick="backToPublicFeed()">&#8592; Back to Feed</button>
+                </div>
+                <div id="post-detail-content"></div>
+            </div>
+
             <!-- Load more / empty -->
             <div id="load-more" class="load-more" style="display:none;">
                 <button onclick="loadMore()">Load older messages</button>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -384,6 +384,58 @@ body {
     font-weight: 500;
 }
 
+/* Post detail view */
+.post-detail {
+    display: none;
+}
+.post-detail.visible { display: block; }
+.post-detail-back {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+}
+.post-detail-back button {
+    background: #2a2d37;
+    border: none;
+    color: #aaa;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+.post-detail-back button:hover { background: #3a3d47; color: #ddd; }
+.post-detail-content {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 1.5rem;
+}
+.post-detail-content .post-sender {
+    font-size: 0.9rem;
+    color: #aaa;
+    margin-bottom: 0.5rem;
+}
+.post-detail-content .post-sender.self { color: #5566cc; }
+.post-detail-content .post-time {
+    font-size: 0.8rem;
+    color: #666;
+    margin-bottom: 1rem;
+}
+.post-detail-content .post-body {
+    font-size: 1rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.message.clickable {
+    cursor: pointer;
+}
+.message.clickable:hover {
+    border-color: #5566cc;
+}
+
 /* Toast notification */
 .toast {
     position: fixed;


### PR DESCRIPTION
This commit implements Phase 6 of the web application plan, which adds
public posting functionality with a dedicated post detail view.

Key changes:
- Added post detail view UI with back navigation to public feed
- Made public messages clickable to navigate to detail view
- Enhanced post detail shows full message with sender, timestamp, and body
- Updated CSS styling for post detail view with hover states
- Added navigation between feed and detail views
- Marked Phase 6 as complete in PLAN.md

Phase 6.1 (Public feed view) was already implemented in previous phases
with the Public filter button and compose functionality. This commit
completes Phase 6.2 by adding the post detail view.

https://claude.ai/code/session_01LzWQ2ojR5uSQrrqvA4SvyE