### PR TITLE
Implement phases 8-10: reactions, replies, and user profiles

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -411,7 +411,7 @@ GET    /api/attachments/:content_hash    -- download attachment
 
 ---
 
-## Phase 8 — Reactions (Upvote / Downvote)
+## Phase 8 — Reactions (Upvote / Downvote) [DONE]
 
 **Goal**: Allow reacting to public posts with upvotes and downvotes.
 
@@ -459,7 +459,7 @@ GET    /api/messages/:message_id/reactions
 
 ---
 
-## Phase 9 — Replies (Threads)
+## Phase 9 — Replies (Threads) [DONE]
 
 **Goal**: Support threaded replies on public and group posts.
 
@@ -500,7 +500,7 @@ POST   /api/messages/:message_id/reply   { body }
 
 ---
 
-## Phase 10 — User Profiles
+## Phase 10 — User Profiles [DONE]
 
 **Goal**: Editable user profiles with separate public and friends-only variants.
 

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -20,6 +20,15 @@
     <div class="container">
         <!-- Sidebar -->
         <div class="sidebar">
+            <!-- My profile (Phase 10) -->
+            <div class="profile-card" id="my-profile-card" onclick="showMyProfile()">
+                <div class="profile-avatar" id="my-profile-avatar"></div>
+                <div class="profile-info">
+                    <div class="profile-name" id="my-profile-name">Me</div>
+                    <div class="profile-bio" id="my-profile-bio"></div>
+                </div>
+            </div>
+
             <!-- Friends list -->
             <div class="friends-panel">
                 <h2>Friends</h2>
@@ -94,6 +103,46 @@
                     <button onclick="backToPublicFeed()">&#8592; Back to Feed</button>
                 </div>
                 <div id="post-detail-content"></div>
+                <!-- Reply compose (Phase 9) -->
+                <div class="reply-compose" id="reply-compose">
+                    <textarea id="reply-body" placeholder="Write a reply..."></textarea>
+                    <div class="reply-compose-actions">
+                        <button onclick="sendReply()">Reply</button>
+                    </div>
+                </div>
+                <!-- Replies list (Phase 9) -->
+                <div id="post-replies"></div>
+                <div id="replies-load-more" class="load-more" style="display:none;">
+                    <button onclick="loadMoreReplies()">Load more replies</button>
+                </div>
+            </div>
+
+            <!-- Profile view (Phase 10) -->
+            <div id="profile-view" class="profile-view">
+                <div class="profile-view-back">
+                    <button onclick="backFromProfile()">&#8592; Back</button>
+                </div>
+                <div id="profile-view-content"></div>
+            </div>
+
+            <!-- Profile edit (Phase 10) -->
+            <div id="profile-edit" class="profile-edit">
+                <div class="profile-edit-back">
+                    <button onclick="backFromProfile()">&#8592; Back</button>
+                    <span>Edit Profile</span>
+                </div>
+                <div class="profile-edit-form">
+                    <label>Display Name</label>
+                    <input type="text" id="profile-display-name" placeholder="Your name" />
+                    <label>Bio</label>
+                    <textarea id="profile-bio" placeholder="Tell us about yourself..." rows="3"></textarea>
+                    <label>Avatar (upload an image first)</label>
+                    <input type="text" id="profile-avatar-hash" placeholder="Attachment content hash" />
+                    <div class="form-actions">
+                        <button class="btn-secondary" onclick="backFromProfile()">Cancel</button>
+                        <button class="btn-primary" onclick="saveProfile()">Save</button>
+                    </div>
+                </div>
             </div>
 
             <!-- Load more / empty -->

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -541,6 +541,321 @@ body {
     background: #1a2a3a !important;
 }
 
+/* Reactions (Phase 8) */
+.msg-reactions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+    font-size: 0.8rem;
+}
+.reaction-btn {
+    background: #0f1117;
+    border: 1px solid #2a2d37;
+    color: #aaa;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    transition: all 0.2s;
+}
+.reaction-btn:hover { border-color: #5566cc; color: #ddd; }
+.reaction-btn.active { border-color: #5566cc; background: #2a2d47; color: #fff; }
+.reaction-btn .count { font-weight: 600; }
+
+/* Reply count indicator */
+.msg-reply-count {
+    font-size: 0.75rem;
+    color: #888;
+    margin-top: 0.3rem;
+    cursor: pointer;
+}
+.msg-reply-count:hover { color: #5566cc; }
+
+/* Reply compose (Phase 9) */
+.reply-compose {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 1rem;
+    margin-top: 1rem;
+}
+.reply-compose textarea {
+    width: 100%;
+    background: #0f1117;
+    border: 1px solid #2a2d37;
+    color: #e0e0e0;
+    border-radius: 6px;
+    padding: 0.5rem;
+    font-family: inherit;
+    font-size: 0.85rem;
+    resize: vertical;
+    min-height: 50px;
+}
+.reply-compose textarea:focus { outline: none; border-color: #5566cc; }
+.reply-compose-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.5rem;
+}
+.reply-compose-actions button {
+    background: #5566cc;
+    border: none;
+    color: #fff;
+    padding: 0.3rem 0.8rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+.reply-compose-actions button:hover { background: #6677dd; }
+
+/* Reply items */
+.reply-item {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-left: 3px solid #3a3d47;
+    border-radius: 0 8px 8px 0;
+    padding: 0.6rem 0.8rem;
+    margin-top: 0.5rem;
+    margin-left: 1rem;
+}
+.reply-item .msg-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.3rem;
+}
+.reply-item .msg-sender {
+    font-size: 0.8rem;
+    color: #aaa;
+}
+.reply-item .msg-sender.self { color: #5566cc; }
+.reply-item .msg-time {
+    font-size: 0.7rem;
+    color: #666;
+    margin-left: auto;
+}
+.reply-item .msg-body {
+    font-size: 0.85rem;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+/* Profile card (Phase 10) */
+.profile-card {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+    transition: border-color 0.2s;
+}
+.profile-card:hover { border-color: #5566cc; }
+.profile-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #2a2d47;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #5566cc;
+    font-size: 1.2rem;
+    font-weight: 700;
+    flex-shrink: 0;
+    overflow: hidden;
+}
+.profile-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+.profile-info { flex: 1; min-width: 0; }
+.profile-name {
+    font-size: 0.9rem;
+    color: #e0e0e0;
+    font-weight: 500;
+}
+.profile-bio {
+    font-size: 0.75rem;
+    color: #888;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Profile view (Phase 10) */
+.profile-view {
+    display: none;
+}
+.profile-view.visible { display: block; }
+.profile-view-back {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+}
+.profile-view-back button {
+    background: #2a2d37;
+    border: none;
+    color: #aaa;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+.profile-view-back button:hover { background: #3a3d47; color: #ddd; }
+.profile-view-content {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 1.5rem;
+}
+.profile-view-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+.profile-view-avatar {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: #2a2d47;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #5566cc;
+    font-size: 1.8rem;
+    font-weight: 700;
+    flex-shrink: 0;
+    overflow: hidden;
+}
+.profile-view-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+.profile-view-name {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: #fff;
+}
+.profile-view-id {
+    font-size: 0.75rem;
+    color: #666;
+}
+.profile-view-bio {
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: #ccc;
+    margin-bottom: 1rem;
+    white-space: pre-wrap;
+}
+.profile-view-fields {
+    font-size: 0.85rem;
+    color: #aaa;
+}
+.profile-view-fields dt {
+    color: #888;
+    font-weight: 600;
+    margin-top: 0.5rem;
+}
+.profile-view-fields dd {
+    margin-left: 0;
+    color: #ccc;
+}
+
+/* Profile edit (Phase 10) */
+.profile-edit {
+    display: none;
+}
+.profile-edit.visible { display: block; }
+.profile-edit-back {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.profile-edit-back button {
+    background: #2a2d37;
+    border: none;
+    color: #aaa;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+.profile-edit-back button:hover { background: #3a3d47; color: #ddd; }
+.profile-edit-back span {
+    font-size: 1rem;
+    color: #e0e0e0;
+    font-weight: 500;
+}
+.profile-edit-form {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 1.5rem;
+}
+.profile-edit-form label {
+    display: block;
+    font-size: 0.8rem;
+    color: #888;
+    margin-bottom: 0.25rem;
+    margin-top: 0.75rem;
+}
+.profile-edit-form label:first-child { margin-top: 0; }
+.profile-edit-form input,
+.profile-edit-form textarea {
+    width: 100%;
+    background: #0f1117;
+    border: 1px solid #2a2d37;
+    color: #e0e0e0;
+    border-radius: 4px;
+    padding: 0.5rem;
+    font-size: 0.85rem;
+    font-family: inherit;
+}
+.profile-edit-form input:focus,
+.profile-edit-form textarea:focus { outline: none; border-color: #5566cc; }
+.profile-edit-form .form-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+.profile-edit-form button {
+    flex: 1;
+    padding: 0.5rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    border: none;
+}
+.profile-edit-form .btn-primary {
+    background: #5566cc;
+    color: #fff;
+}
+.profile-edit-form .btn-primary:hover { background: #6677dd; }
+.profile-edit-form .btn-secondary {
+    background: #2a2d37;
+    color: #aaa;
+}
+.profile-edit-form .btn-secondary:hover { background: #3a3d47; }
+
 /* Toast notification */
 .toast {
     position: fixed;


### PR DESCRIPTION
Phase 8 - Reactions (Upvote/Downvote):
- Add reactions table with upsert/delete/count CRUD operations
- Add API endpoints: POST/DELETE /api/messages/:id/react, GET /api/messages/:id/reactions
- Frontend: upvote/downvote buttons on all messages with live count updates
- Reactions are broadcast as signed public messages to relays

Phase 9 - Replies (Threads):
- Add reply_to column to messages table with migration support
- Add list_replies/count_replies storage methods
- Add API endpoints: POST /api/messages/:id/reply, GET /api/messages/:id/replies
- Frontend: reply counts on timeline posts, threaded reply view in post detail,
  reply compose box with Ctrl+Enter support
- Replies inherit parent message kind (public or group)

Phase 10 - User Profiles:
- Add profiles table with upsert/get/upsert_if_newer CRUD operations
- Add API endpoints: GET/PUT /api/profile, GET /api/peers/:id/profile
- Profile has public_fields and friends_fields (JSON) for tiered visibility
- Profile updates broadcast as public messages; friends-only fields sent via
  encrypted direct messages to each friend
- Frontend: profile card in sidebar, profile edit form, peer profile view,
  clickable sender names throughout the UI

All changes include unit tests for new storage operations. All 65 tests pass.

https://claude.ai/code/session_01MrxBRNH6MvfX2wF3e9nuLw