### PR TITLE
Add CLI arguments and relay connection status monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +333,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +380,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -997,6 +1093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1295,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -1817,6 +1925,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,6 +1994,7 @@ dependencies = [
  "axum-extra",
  "base64",
  "chacha20poly1305",
+ "clap",
  "crossterm",
  "ed25519-dalek",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ tower-http = { version = "0.5", features = ["set-header"] }
 mime_guess = "2"
 ureq = { version = "2.10", features = ["json", "tls"] }
 axum-extra = { version = "0.9", features = ["multipart"] }
+clap = { version = "4", features = ["derive"] }

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -17,6 +17,12 @@
         <div class="peer-id" id="peer-id" title=""></div>
     </div>
 
+    <!-- Relay status banner -->
+    <div class="relay-banner" id="relay-banner" style="display:none;">
+        <span class="relay-banner-icon">&#9888;</span>
+        <span id="relay-banner-text">Relay unavailable</span>
+    </div>
+
     <div class="container">
         <!-- Sidebar -->
         <div class="sidebar">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -30,6 +30,24 @@ body {
     max-width: 200px; overflow: hidden; text-overflow: ellipsis;
 }
 
+/* Relay status banner */
+.relay-banner {
+    background: #3a2a10;
+    border-bottom: 1px solid #6b4f1f;
+    color: #f0c040;
+    padding: 0.5rem 1.5rem;
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.relay-banner-icon { font-size: 1rem; }
+.relay-banner.connected {
+    background: #1a3a1a;
+    border-bottom-color: #2a5a2a;
+    color: #4caf50;
+}
+
 /* Layout */
 .container {
     display: flex;


### PR DESCRIPTION
## Summary
This PR adds command-line argument support via `clap` and implements relay connection status monitoring with real-time UI updates.

## Key Changes

### CLI Arguments & Configuration
- Added `clap` dependency with derive feature for structured CLI argument parsing
- Introduced `Cli` struct with three configurable options:
  - `--bind` / `-b`: HTTP server bind address (default: 127.0.0.1:3000)
  - `--data-dir` / `-d`: Data directory for identity and database (default: ~/.tenet)
  - `--relay-url` / `-r`: Relay server URL for messages
- Updated `Config::from_env()` to `Config::from_cli_and_env()` to merge CLI args with environment variables (CLI takes precedence)
- Improved startup logging to display configuration details

### Relay Connection Status Monitoring
- Added `relay_connected: Arc<AtomicBool>` to `AppState` to track relay connectivity
- Added `RelayStatus` variant to `WsEvent` enum to broadcast relay status changes
- Implemented initial relay connectivity check before server startup with user-friendly warnings
- Enhanced `relay_sync_loop()` to:
  - Track connection state transitions
  - Broadcast status changes via WebSocket
  - Provide clearer logging for connection/disconnection events
- Updated `/health` endpoint to include `relay_connected` boolean field

### Web UI Enhancements
- Added relay status banner that displays when relay is unavailable
- Implemented `updateRelayBanner()` function to manage banner visibility and styling
- Added WebSocket event handler for `relay_status` events
- Added toast notifications for relay connection/disconnection events
- Banner styling with warning colors (#3a2a10 background, #f0c040 text) and connected state styling

## Implementation Details
- CLI arguments are parsed at startup and take precedence over environment variables
- Relay connectivity is checked once before server startup to provide immediate feedback
- Background sync loop continues with exponential backoff on failures
- WebSocket broadcasts ensure all connected clients see relay status changes in real-time
- Relay banner only displays when a relay is configured; hidden for local-only mode

https://claude.ai/code/session_01QeDaSGzZgNRQUguxCqH89N