### PR TITLE
Implement friend request protocol with key exchange handshake

### DIFF
--- a/docs/add_peer_flow.md
+++ b/docs/add_peer_flow.md
@@ -1,0 +1,152 @@
+# Add Peer / Friend Request Flow
+
+This document describes the friend request protocol, how key exchange works during the process, and why it is secure.
+
+## Overview
+
+Adding a friend in Tenet is a multi-step process that exchanges cryptographic keys between two peers. The initiator only needs the recipient's **Peer ID** to start the process. All signing and encryption keys are exchanged automatically as part of the friend request handshake.
+
+## Cryptographic Primitives
+
+Tenet uses industry-standard cryptographic primitives:
+
+| Primitive | Algorithm | Purpose |
+|-----------|-----------|---------|
+| Asymmetric encryption | HPKE (X25519-HKDF-SHA256 + ChaCha20Poly1305) | Wrapping per-message content keys |
+| Symmetric encryption | ChaCha20Poly1305 | Encrypting message payloads |
+| Signing | Ed25519 | Message authentication and integrity |
+| Hashing | SHA-256 | Content addressing (ContentId) |
+
+### How HPKE Encryption Works
+
+HPKE (Hybrid Public Key Encryption) combines asymmetric and symmetric cryptography for efficient message encryption:
+
+1. **Key generation**: Each peer generates an X25519 key pair (for encryption) and an Ed25519 key pair (for signing). The Peer ID is derived from `SHA-256(public_encryption_key)`, encoded as base64url.
+
+2. **Sending an encrypted message**:
+   - Generate a random 32-byte **content key**
+   - Encrypt the message body with **ChaCha20Poly1305** using the content key (with a random 12-byte nonce and authenticated additional data)
+   - **Wrap** the content key using HPKE: this performs an X25519 Diffie-Hellman exchange with the recipient's public key, derives a shared secret via HKDF-SHA256, and encrypts the content key with ChaCha20Poly1305
+   - Sign the message header with the sender's **Ed25519 private key**
+   - Package everything into an Envelope: header + wrapped key + encrypted payload
+
+3. **Receiving an encrypted message**:
+   - Verify the Ed25519 signature on the header using the sender's known signing public key
+   - **Unwrap** the content key using the recipient's X25519 private key (reverse of the HPKE wrapping)
+   - Decrypt the message body with ChaCha20Poly1305 using the recovered content key
+
+This approach means each message has a unique content key, so compromising one message does not compromise others.
+
+## Friend Request Protocol
+
+### Step 1: Send Friend Request (Initiator)
+
+The initiator knows only the recipient's Peer ID. They send a **Meta message** of type `friend_request` to the recipient's relay inbox containing:
+
+```json
+{
+  "type": "friend_request",
+  "peer_id": "<initiator's peer id>",
+  "signing_public_key": "<initiator's Ed25519 public key, hex>",
+  "encryption_public_key": "<initiator's X25519 public key, hex>",
+  "message": "Hi, I'd like to connect!"
+}
+```
+
+This message is delivered as a plaintext Meta envelope (not HPKE-encrypted) because the initiator does not yet have the recipient's encryption public key. However:
+
+- The message is delivered through the relay's store-and-forward mechanism to the recipient's inbox only
+- The envelope header is signed with the initiator's Ed25519 key, which the recipient can verify using the signing key included in the request
+
+### Step 2: Recipient Reviews Request
+
+The recipient sees the incoming friend request in their Friend Requests UI. They can:
+
+- **Accept** — proceed to key exchange
+- **Ignore** — dismiss without responding (can be revisited later)
+- **Block** — reject and prevent future requests from this peer
+
+### Step 3: Accept and Respond (Recipient)
+
+If the recipient accepts, they:
+
+1. Store the initiator's signing and encryption public keys locally
+2. Add the initiator as a friend
+3. Send back a **Meta message** of type `friend_accept`:
+
+```json
+{
+  "type": "friend_accept",
+  "peer_id": "<recipient's peer id>",
+  "signing_public_key": "<recipient's Ed25519 public key, hex>",
+  "encryption_public_key": "<recipient's X25519 public key, hex>"
+}
+```
+
+This response is also a plaintext Meta message, since the recipient now has the initiator's encryption key but the initiator does not yet have the recipient's key. The message is signed by the recipient's Ed25519 key.
+
+### Step 4: Initiator Completes Connection
+
+When the initiator receives the `friend_accept` response:
+
+1. Store the recipient's signing and encryption public keys locally
+2. Mark the friend request as accepted
+3. The initiator now has the recipient's encryption key, so all subsequent messages can be HPKE-encrypted
+
+At this point, both peers have each other's keys and can exchange fully encrypted Direct messages.
+
+## Security Properties
+
+### What is protected
+
+- **Message confidentiality**: After the handshake, all Direct messages use HPKE encryption. Only the intended recipient can decrypt them.
+- **Message integrity**: Every envelope header is Ed25519-signed. Tampering is detectable.
+- **Forward secrecy (per-message)**: Each message uses a fresh random content key. Compromising one content key does not reveal other messages.
+- **Content addressing**: Message IDs are SHA-256 hashes of the payload, enabling deduplication without reading content.
+
+### Trust model
+
+- **Trust on first use (TOFU)**: The friend request includes the sender's public keys. The recipient trusts that these keys belong to the claimed Peer ID. This is similar to how SSH or Signal handle initial key exchange.
+- **Peer ID binding**: Since the Peer ID is derived from `SHA-256(public_encryption_key)`, an attacker cannot claim a different peer's ID without possessing their private key.
+- **Relay is untrusted**: The relay stores and forwards envelopes but cannot decrypt HPKE-encrypted content. It can observe metadata (sender ID, recipient ID, timestamps, message sizes).
+
+### What is NOT protected during the handshake
+
+- **Friend request content**: The initial friend request and acceptance are plaintext Meta messages. A relay operator (or network observer) can see who is requesting to be friends with whom, and the optional request message.
+- **Metadata**: The relay always sees sender/recipient IDs and timing. This is inherent to the store-and-forward design.
+
+### Threat mitigations
+
+| Threat | Mitigation |
+|--------|------------|
+| Relay reads messages | HPKE encryption (post-handshake) |
+| Message tampering | Ed25519 signatures on headers |
+| Replay attacks | Content-addressed deduplication + TTL enforcement |
+| Spam friend requests | Block functionality prevents repeat requests |
+| Key impersonation | Peer ID derived from public key (TOFU model) |
+
+## Sequence Diagram
+
+```
+Initiator                     Relay                      Recipient
+    |                           |                            |
+    |-- FriendRequest --------->|                            |
+    |   (signing_key,           |-- store in inbox --------->|
+    |    encryption_key,        |                            |
+    |    message)               |                     [Review request]
+    |                           |                            |
+    |                           |<--- FriendAccept ---------|
+    |<-- deliver from inbox ----|    (signing_key,           |
+    |                           |     encryption_key)        |
+    |                           |                            |
+    [Store keys, mark accepted] |              [Store keys, add friend]
+    |                           |                            |
+    |== Encrypted Direct msgs ==|== Encrypted Direct msgs ==|
+    |   (HPKE + ChaCha20)       |   (HPKE + ChaCha20)       |
+```
+
+## Block and Ignore Behavior
+
+- **Block**: Stored locally on the recipient's client. Future friend requests from the blocked peer are automatically ignored. The blocked peer receives no indication they have been blocked.
+- **Ignore**: The request remains in the recipient's request list but is hidden by default. It can be accepted or blocked later.
+- Both block and ignore are client-side only — no message is sent back to the initiator. From the initiator's perspective, the request remains "pending."

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -301,6 +301,17 @@ pub enum MetaMessage {
         peer_id: String,
         since_timestamp: u64,
     },
+    FriendRequest {
+        peer_id: String,
+        signing_public_key: String,
+        encryption_public_key: String,
+        message: Option<String>,
+    },
+    FriendAccept {
+        peer_id: String,
+        signing_public_key: String,
+        encryption_public_key: String,
+    },
 }
 
 #[derive(Debug)]

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -34,6 +34,13 @@
                     <div class="profile-bio" id="my-profile-bio"></div>
                 </div>
             </div>
+            <div class="peer-id-display" id="peer-id-display">
+                <span class="peer-id-label">Your Peer ID</span>
+                <div class="peer-id-row">
+                    <code class="peer-id-full" id="peer-id-full"></code>
+                    <button class="copy-btn" onclick="event.stopPropagation();copyPeerId()" title="Copy Peer ID">Copy</button>
+                </div>
+            </div>
 
             <!-- Friends list -->
             <div class="friends-panel">
@@ -42,16 +49,31 @@
                 <button class="add-friend-btn" onclick="toggleAddFriendForm()">+ Add Friend</button>
             </div>
 
-            <!-- Add friend form -->
+            <!-- Add friend form (simplified - just peer ID + message) -->
             <div id="add-friend-form" class="add-friend-form">
-                <h3>Add Friend</h3>
+                <h3>Send Friend Request</h3>
                 <input type="text" id="friend-peer-id" placeholder="Peer ID" />
-                <input type="text" id="friend-display-name" placeholder="Display Name (optional)" />
-                <input type="text" id="friend-signing-key" placeholder="Signing Public Key" />
-                <input type="text" id="friend-enc-key" placeholder="Encryption Key (optional)" />
+                <input type="text" id="friend-message" placeholder="Message (optional)" />
                 <div class="form-actions">
                     <button class="btn-secondary" onclick="toggleAddFriendForm()">Cancel</button>
-                    <button class="btn-primary" onclick="addFriend()">Add</button>
+                    <button class="btn-primary" onclick="sendFriendRequest()">Send Request</button>
+                </div>
+            </div>
+
+            <!-- Friend Requests panel -->
+            <div class="friend-requests-panel" id="friend-requests-panel">
+                <div class="friend-requests-header" onclick="toggleFriendRequests()">
+                    <h2>Friend Requests <span class="fr-badge" id="fr-pending-badge"></span></h2>
+                </div>
+                <div id="friend-requests-content" class="friend-requests-content">
+                    <div class="fr-tabs">
+                        <button class="fr-tab active" data-fr-tab="pending" onclick="switchFrTab('pending')">Pending</button>
+                        <button class="fr-tab" data-fr-tab="history" onclick="switchFrTab('history')">History</button>
+                    </div>
+                    <div class="fr-toggle-hidden">
+                        <label><input type="checkbox" id="fr-show-hidden" onchange="loadFriendRequests()"> Show blocked &amp; ignored</label>
+                    </div>
+                    <div id="friend-requests-list"></div>
                 </div>
             </div>
         </div>
@@ -138,6 +160,11 @@
                     <span>Edit Profile</span>
                 </div>
                 <div class="profile-edit-form">
+                    <label>Your Peer ID</label>
+                    <div class="profile-peer-id-row">
+                        <code class="profile-peer-id" id="profile-edit-peer-id"></code>
+                        <button type="button" class="copy-btn" onclick="copyPeerId()">Copy</button>
+                    </div>
                     <label>Display Name</label>
                     <input type="text" id="profile-display-name" placeholder="Your name" />
                     <label>Bio</label>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -874,6 +874,213 @@ body {
 }
 .profile-edit-form .btn-secondary:hover { background: #3a3d47; }
 
+/* Peer ID display in sidebar */
+.peer-id-display {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 0.6rem 0.75rem;
+    margin-bottom: 1rem;
+}
+.peer-id-label {
+    font-size: 0.7rem;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    display: block;
+    margin-bottom: 0.35rem;
+}
+.peer-id-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.peer-id-full {
+    font-size: 0.7rem;
+    color: #aaa;
+    word-break: break-all;
+    flex: 1;
+    line-height: 1.4;
+    font-family: monospace;
+}
+.copy-btn {
+    background: #2a2d47;
+    border: 1px solid #5566cc;
+    color: #fff;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.7rem;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+.copy-btn:hover { background: #3a3d57; }
+
+/* Friend Requests panel */
+.friend-requests-panel {
+    background: #1a1d27;
+    border: 1px solid #2a2d37;
+    border-radius: 8px;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+}
+.friend-requests-header {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+}
+.friend-requests-header h2 {
+    font-size: 0.9rem;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.fr-badge {
+    background: #5566cc;
+    color: #fff;
+    font-size: 0.65rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 10px;
+    display: none;
+}
+.friend-requests-content {
+    display: none;
+    margin-top: 0.75rem;
+}
+.friend-requests-content.visible { display: block; }
+.fr-tabs {
+    display: flex;
+    gap: 0.25rem;
+    margin-bottom: 0.5rem;
+}
+.fr-tab {
+    background: #0f1117;
+    border: 1px solid #2a2d37;
+    color: #aaa;
+    padding: 0.25rem 0.6rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.75rem;
+}
+.fr-tab:hover { border-color: #555; color: #ddd; }
+.fr-tab.active {
+    background: #2a2d47;
+    border-color: #5566cc;
+    color: #fff;
+}
+.fr-toggle-hidden {
+    font-size: 0.7rem;
+    color: #666;
+    margin-bottom: 0.5rem;
+}
+.fr-toggle-hidden label {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: pointer;
+}
+.fr-toggle-hidden input { margin: 0; }
+.fr-empty {
+    text-align: center;
+    color: #666;
+    font-size: 0.8rem;
+    padding: 0.75rem 0;
+}
+.fr-item {
+    background: #0f1117;
+    border: 1px solid #2a2d37;
+    border-radius: 6px;
+    padding: 0.5rem 0.6rem;
+    margin-bottom: 0.35rem;
+}
+.fr-item-header {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+}
+.fr-direction {
+    color: #888;
+    font-size: 0.7rem;
+}
+.fr-peer {
+    color: #e0e0e0;
+    font-weight: 500;
+}
+.fr-time {
+    color: #666;
+    font-size: 0.7rem;
+    margin-left: auto;
+}
+.fr-message {
+    font-size: 0.75rem;
+    color: #aaa;
+    margin-top: 0.25rem;
+    font-style: italic;
+}
+.fr-actions {
+    display: flex;
+    gap: 0.35rem;
+    margin-top: 0.4rem;
+}
+.fr-actions button {
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.7rem;
+    border: none;
+}
+.fr-accept { background: #2a5a2a; color: #4caf50; }
+.fr-accept:hover { background: #3a6a3a; }
+.fr-ignore { background: #3a3a2a; color: #f0c040; }
+.fr-ignore:hover { background: #4a4a3a; }
+.fr-block { background: #3a1a1a; color: #f44336; }
+.fr-block:hover { background: #4a2a2a; }
+.fr-status {
+    font-size: 0.7rem;
+    margin-top: 0.3rem;
+    font-weight: 600;
+}
+.fr-status.accepted { color: #4caf50; }
+.fr-status.pending { color: #f0c040; }
+.fr-status.ignored { color: #888; }
+.fr-status.blocked { color: #f44336; }
+
+/* Profile peer ID row */
+.profile-peer-id-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+.profile-peer-id {
+    font-size: 0.75rem;
+    color: #aaa;
+    word-break: break-all;
+    flex: 1;
+    font-family: monospace;
+    line-height: 1.3;
+}
+.profile-view-id-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    background: #0f1117;
+    border: 1px solid #2a2d37;
+    border-radius: 6px;
+    padding: 0.5rem;
+}
+.profile-view-id-full {
+    font-size: 0.7rem;
+    color: #aaa;
+    word-break: break-all;
+    flex: 1;
+    font-family: monospace;
+    line-height: 1.4;
+}
+
 /* Toast notification */
 .toast {
     position: fixed;


### PR DESCRIPTION
## Summary

This PR implements a complete friend request protocol for Tenet that enables two peers to establish a secure connection by exchanging cryptographic keys through a multi-step handshake. The initiator only needs the recipient's Peer ID to start the process; all signing and encryption keys are exchanged automatically during the friend request flow.

## Key Changes

- **Documentation**: Added comprehensive `docs/add_peer_flow.md` explaining the friend request protocol, cryptographic primitives (HPKE, Ed25519, ChaCha20Poly1305), security properties, and threat mitigations

- **Protocol Extensions**: Extended `MetaMessage` enum with two new message types:
  - `FriendRequest`: Initiator sends peer ID, signing key, encryption key, and optional message
  - `FriendAccept`: Recipient responds with their keys to complete the handshake

- **Storage Layer**: Added `FriendRequestRow` struct and database table to track friend requests with:
  - Status tracking (pending, accepted, ignored, blocked)
  - Direction tracking (incoming vs outgoing)
  - Storage of peer's public keys for later use
  - Indexes for efficient querying by peer and status

- **API Endpoints**: Implemented four new REST endpoints:
  - `POST /api/friend-requests` - Send a friend request
  - `GET /api/friend-requests` - List requests with optional filtering by status/direction
  - `POST /api/friend-requests/:id/accept` - Accept an incoming request and add peer as friend
  - `POST /api/friend-requests/:id/ignore` - Ignore a request (client-side only)
  - `POST /api/friend-requests/:id/block` - Block a peer (prevents future requests)

- **Sync Logic**: Enhanced `sync_once()` to handle incoming `FriendRequest` and `FriendAccept` meta messages:
  - Validates against blocked peers
  - Prevents duplicate pending requests
  - Automatically stores peer keys when accepting
  - Broadcasts WebSocket events for UI updates

- **UI Components**: Redesigned friend management interface:
  - Simplified "Add Friend" form (only peer ID + optional message)
  - New "Friend Requests" panel with pending/history tabs
  - Accept/Ignore/Block actions for incoming requests
  - Peer ID display and copy functionality in sidebar and profile views
  - Badge showing count of pending incoming requests
  - Real-time updates via WebSocket events

## Implementation Details

- Friend requests are sent as plaintext Meta envelopes (not HPKE-encrypted) since the initiator doesn't yet have the recipient's encryption key, but are signed with the initiator's Ed25519 key for authenticity
- The recipient's acceptance response is also plaintext but signed, allowing the initiator to verify and store the recipient's keys
- After the handshake completes, all subsequent Direct messages use full HPKE encryption
- Block and ignore are client-side only—no rejection message is sent back to the initiator
- Peer ID is derived from `SHA-256(public_encryption_key)` in base64url format, binding identity to the encryption key

https://claude.ai/code/session_01822oXAgT8Hq4zAK8vpxFZh