### PR TITLE
Fix friend request delivery and improve UX

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -786,10 +786,12 @@ async function loadFriendRequests() {
 }
 
 function updateFrBadge() {
-    const pending = friendRequests.filter(r => r.status === 'pending' && r.direction === 'incoming');
+    const pendingIncoming = friendRequests.filter(r => r.status === 'pending' && r.direction === 'incoming');
+    const pendingOutgoing = friendRequests.filter(r => r.status === 'pending' && r.direction === 'outgoing');
+    const totalPending = pendingIncoming.length + pendingOutgoing.length;
     const badge = document.getElementById('fr-pending-badge');
-    if (pending.length > 0) {
-        badge.textContent = pending.length;
+    if (totalPending > 0) {
+        badge.textContent = totalPending;
         badge.style.display = '';
     } else {
         badge.style.display = 'none';

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -65,7 +65,7 @@
                 <div class="friend-requests-header" onclick="toggleFriendRequests()">
                     <h2>Friend Requests <span class="fr-badge" id="fr-pending-badge"></span></h2>
                 </div>
-                <div id="friend-requests-content" class="friend-requests-content">
+                <div id="friend-requests-content" class="friend-requests-content visible">
                     <div class="fr-tabs">
                         <button class="fr-tab active" data-fr-tab="pending" onclick="switchFrTab('pending')">Pending</button>
                         <button class="fr-tab" data-fr-tab="history" onclick="switchFrTab('history')">History</button>


### PR DESCRIPTION
The core bug: sync_once() called RelayClient.sync_inbox() which drained the relay inbox, then tried to fetch raw envelopes again (empty). Messages from unknown senders (friend requests) were silently discarded by sync_inbox because it requires registered peers for signature verification.

Fix: Rewrite sync_once() to fetch raw envelopes directly (single fetch) and process them inline. Meta messages from ALL senders (including unknown) are now handled for friend requests. Non-meta messages are verified against known peers and decrypted manually.

Other changes:
- Add eprintln logging throughout friend request send/receive/accept flow for debugging
- Show friend requests panel expanded by default in web UI
- Badge shows total pending count (incoming + outgoing)
- Remove unused RelayClient/ClientConfig/ClientEncryption imports

https://claude.ai/code/session_01822oXAgT8Hq4zAK8vpxFZh