### PR TITLE
Handle duplicate friend requests gracefully

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -732,7 +732,7 @@ function toggleAddFriendForm() {
     }
 }
 
-async function sendFriendRequest() {
+async function sendFriendRequest(force) {
     const peerId = document.getElementById('friend-peer-id').value.trim();
     const message = document.getElementById('friend-message').value.trim();
 
@@ -744,13 +744,20 @@ async function sendFriendRequest() {
     try {
         const payload = { peer_id: peerId };
         if (message) payload.message = message;
+        if (force) payload.force = true;
 
         await apiPost('/api/friend-requests', payload);
         showToast('Friend request sent');
         toggleAddFriendForm();
         await loadFriendRequests();
     } catch (e) {
-        showToast('Failed to send request: ' + e.message);
+        if (e.message && e.message.includes('already pending')) {
+            if (confirm('A friend request to this peer is already pending. Resend it?')) {
+                await sendFriendRequest(true);
+            }
+        } else {
+            showToast('Failed to send request: ' + e.message);
+        }
     }
 }
 


### PR DESCRIPTION
Sender side:
- API accepts `force: true` to resend a pending request
- Without force, returns 409 with "friend request already pending"
- Web UI shows a confirmation dialog: "Already pending. Resend it?"
- On confirm, resends with force=true, refreshing the existing record

Receiver side:
- On re-receive, checks for existing request from same peer
- If pending: refreshes message/keys/timestamp, emits WS event
- If ignored or blocked: silently drops (does not resurface)
- If accepted: skips (already friends)
- Only creates a new record if no prior request exists

Storage:
- Add find_request_between() to look up existing requests
- Add refresh_friend_request() to update message/keys/timestamp

https://claude.ai/code/session_01822oXAgT8Hq4zAK8vpxFZh