### PR TITLE
Add WebSocket support for real-time message delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -725,6 +725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
@@ -2028,6 +2040,7 @@ dependencies = [
  "clap",
  "crossterm",
  "ed25519-dalek",
+ "futures-util",
  "hex",
  "hpke",
  "mime_guess",
@@ -2043,6 +2056,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+ "tokio-tungstenite 0.21.0",
  "toml",
  "tower-http",
  "ureq",
@@ -2106,6 +2120,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
@@ -2113,7 +2139,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -2219,6 +2245,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,5 @@ clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"
+tokio-tungstenite = "0.21"
+futures-util = "0.3"


### PR DESCRIPTION
## Summary
This PR adds WebSocket support to the relay server, enabling clients to receive messages in real-time via WebSocket connections instead of relying solely on polling. Messages are now broadcast to all connected WebSocket subscribers for a given recipient while maintaining backward compatibility with the existing HTTP polling interface.

## Key Changes

- **WebSocket endpoint**: Added `/ws/{recipient_id}` route that upgrades HTTP connections to WebSocket
- **Broadcast system**: Implemented a per-recipient broadcast channel system using `tokio::sync::broadcast` to notify all connected subscribers when new messages arrive
- **Message notification**: Modified `store_envelope` and `store_envelopes_batch` handlers to notify WebSocket subscribers when messages are accepted
- **Client helper**: Added `ClientConfig::ws_url()` method to construct WebSocket URLs from HTTP relay URLs
- **Connection handling**: Implemented proper WebSocket connection lifecycle management with ping/pong support and graceful disconnection
- **Dependencies**: Added `tokio-tungstenite 0.21` and `futures-util 0.3` for WebSocket functionality

## Implementation Details

- WebSocket subscribers are managed in a `HashMap<String, broadcast::Sender<Value>>` keyed by recipient ID
- Each recipient gets a broadcast channel with a capacity of 128 messages to handle temporary subscriber lag
- The relay uses `tokio::select!` to multiplex between incoming broadcast messages and WebSocket control frames
- Messages are only broadcast to subscribers when `StoreDecision::Accepted` is returned, not for duplicates
- The implementation maintains full backward compatibility—polling and WebSocket can coexist
- Comprehensive test coverage includes single/multiple subscribers, cross-recipient isolation, batch operations, and error scenarios

## Testing
Added 7 new integration tests covering:
- Real-time message delivery via WebSocket
- Multiple concurrent subscribers to the same recipient
- Message isolation between different recipients
- Coexistence of WebSocket and polling interfaces
- Sequential message delivery
- Batch message notification
- Relay stability after client disconnection

https://claude.ai/code/session_01Snqrk9q5wDDFw8LhXpHsLw