### PR TITLE
Add structured logging with timestamps and colour support

### DIFF
--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -5,6 +5,7 @@ use tenet::relay::{app, RelayConfig, RelayState};
 
 #[tokio::main]
 async fn main() {
+    tenet::logging::init();
     let config = RelayConfig {
         ttl: Duration::from_secs(env_u64("TENET_RELAY_TTL_SECS", 86_400)),
         max_messages: env_usize("TENET_RELAY_MAX_MESSAGES", 1_000),
@@ -33,7 +34,7 @@ async fn main() {
         .unwrap_or_else(|error| panic!("failed to bind {bind}: {error}"));
 
     let local_addr = listener.local_addr().expect("failed to get local address");
-    eprintln!("tenet-relay listening on http://{}", local_addr);
+    tenet::tlog!("tenet-relay listening on http://{}", local_addr);
 
     axum::serve(listener, app)
         .await

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -179,7 +179,7 @@ pub fn migrate_legacy_layout(data_dir: &Path) -> Result<Option<PathBuf>, Identit
     let new_db = db_path(&identity_dir);
     if !new_db.exists() {
         fs::rename(&legacy_db, &new_db)?;
-        eprintln!("  migrated legacy database to identities/{}/", sid);
+        crate::tlog!("  migrated legacy database to identities/{}/", sid);
     }
 
     Ok(Some(identity_dir))
@@ -388,7 +388,7 @@ fn migrate_legacy_json_to_identities(data_dir: &Path) -> Result<(), IdentityErro
     // Run full JSON migration (handles peers, inbox, outbox too)
     let _ = storage.migrate_from_json(data_dir);
 
-    eprintln!("  migrated legacy JSON files to identities/{}/", sid);
+    crate::tlog!("  migrated legacy JSON files to identities/{}/", sid);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod client;
 pub mod crypto;
 pub mod groups;
 pub mod identity;
+pub mod logging;
 pub mod protocol;
 pub mod relay;
 pub mod simulation;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,156 @@
+//! Structured logging with timestamps, source locations, and ANSI colour support.
+//!
+//! Provides the [`tlog!`] macro for consistent log output in the format:
+//!
+//! ```text
+//! 20260211T21:33:12.000 - src/bin/tenet-web.rs:42 - sync: fetched 5 envelope(s)
+//! ```
+//!
+//! When stderr is a terminal, output is colour-coded:
+//! - Timestamps and source locations are dimmed
+//! - Peer IDs and message IDs get consistent colours based on their content
+
+use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::SystemTime;
+
+static COLOUR_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Initialize the logging system. Call once at startup before any logging.
+/// Detects whether stderr supports ANSI colours.
+pub fn init() {
+    let is_terminal = std::io::stderr().is_terminal();
+    COLOUR_ENABLED.store(is_terminal, Ordering::Relaxed);
+}
+
+/// Returns whether ANSI colour output is enabled.
+pub fn colour_enabled() -> bool {
+    COLOUR_ENABLED.load(Ordering::Relaxed)
+}
+
+// ANSI escape codes
+const RESET: &str = "\x1b[0m";
+const DIM: &str = "\x1b[2m";
+
+/// Colour palette for ID hashing — bright, visually distinct colours.
+const ID_COLOURS: &[&str] = &[
+    "\x1b[91m", // bright red
+    "\x1b[92m", // bright green
+    "\x1b[93m", // bright yellow
+    "\x1b[94m", // bright blue
+    "\x1b[95m", // bright magenta
+    "\x1b[96m", // bright cyan
+    "\x1b[31m", // red
+    "\x1b[32m", // green
+    "\x1b[33m", // yellow
+    "\x1b[34m", // blue
+    "\x1b[35m", // magenta
+    "\x1b[36m", // cyan
+];
+
+/// Pick a deterministic colour for the given string.
+fn hash_colour(id: &str) -> &'static str {
+    let hash: u32 = id
+        .bytes()
+        .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
+    ID_COLOURS[(hash as usize) % ID_COLOURS.len()]
+}
+
+const LOG_ID_TRUNCATE_LEN: usize = 7;
+
+fn truncate_id(id: &str) -> &str {
+    let end = id
+        .char_indices()
+        .nth(LOG_ID_TRUNCATE_LEN)
+        .map(|(i, _)| i)
+        .unwrap_or(id.len());
+    &id[..end]
+}
+
+/// Format a peer ID with consistent colour and truncation.
+///
+/// Returns e.g. `p-1GDfZU` (plain) or `\x1b[92mp-1GDfZU\x1b[0m` (colour).
+pub fn peer_id(id: &str) -> String {
+    let short = truncate_id(id);
+    if colour_enabled() {
+        let colour = hash_colour(id);
+        format!("{colour}p-{short}{RESET}")
+    } else {
+        format!("p-{short}")
+    }
+}
+
+/// Format a message ID with consistent colour and truncation.
+pub fn msg_id(id: &str) -> String {
+    let short = truncate_id(id);
+    if colour_enabled() {
+        let colour = hash_colour(id);
+        format!("{colour}m-{short}{RESET}")
+    } else {
+        format!("m-{short}")
+    }
+}
+
+/// Format the current wall-clock time as `YYYYMMDDTHH:MM:SS.mmm`.
+pub fn format_timestamp() -> String {
+    let now = SystemTime::now();
+    let duration = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+    let millis = duration.subsec_millis();
+
+    let time_secs = secs % 86400;
+    let hours = time_secs / 3600;
+    let minutes = (time_secs % 3600) / 60;
+    let seconds = time_secs % 60;
+
+    // Civil date from days since epoch (Howard Hinnant's algorithm).
+    let days = (secs / 86400) as i64;
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!(
+        "{:04}{:02}{:02}T{:02}:{:02}:{:02}.{:03}",
+        y, m, d, hours, minutes, seconds, millis
+    )
+}
+
+/// Emit a log line to stderr with timestamp and source location.
+///
+/// # Usage
+///
+/// ```ignore
+/// tlog!("sync: fetched {} envelope(s)", count);
+/// tlog!("sync: peer {} is now online", logging::peer_id(&pid));
+/// ```
+#[macro_export]
+macro_rules! tlog {
+    ($($arg:tt)*) => {{
+        let msg = format!($($arg)*);
+        let ts = $crate::logging::format_timestamp();
+        let file = file!();
+        let line = line!();
+        if $crate::logging::colour_enabled() {
+            eprintln!(
+                "{DIM}{ts}{RST} {DIM}{file}:{line}{RST} {msg}",
+                DIM = "\x1b[2m",
+                RST = "\x1b[0m",
+                ts = ts,
+                file = file,
+                line = line,
+                msg = msg,
+            );
+        } else {
+            eprintln!("{ts} - {file}:{line} - {msg}");
+        }
+    }};
+}

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -795,22 +795,21 @@ fn log_message(config: &RelayConfig, message: String) {
     if let Some(log_sink) = &config.log_sink {
         log_sink(message);
     } else {
-        println!("{message}");
+        let ts = crate::logging::format_timestamp();
+        if crate::logging::colour_enabled() {
+            println!("\x1b[2m{ts}\x1b[0m {message}");
+        } else {
+            println!("{ts} - {message}");
+        }
     }
 }
 
-const LOG_ID_TRUNCATE_LEN: usize = 7;
-
 fn format_peer_id(peer_id: &str) -> String {
-    format!("p-{}", truncate_id(peer_id))
+    crate::logging::peer_id(peer_id)
 }
 
 fn format_message_id(message_id: &str) -> String {
-    format!("m-{}", truncate_id(message_id))
-}
-
-fn truncate_id(id: &str) -> String {
-    id.chars().take(LOG_ID_TRUNCATE_LEN).collect()
+    crate::logging::msg_id(message_id)
 }
 
 fn count_recent_peers(inner: &RelayStateInner, now: Instant, window: Duration) -> usize {


### PR DESCRIPTION
## Summary

Introduces a new `logging` module that provides structured, timestamped log output with optional ANSI colour support. Replaces ad-hoc `eprintln!` calls throughout the codebase with a consistent `tlog!` macro that includes timestamps, source locations, and colour-coded peer/message IDs.

## Key Changes

- **New `logging` module** (`src/logging.rs`):
  - `init()` function to detect terminal support and enable colours
  - `tlog!` macro for consistent log output with timestamps and file:line info
  - `peer_id()` and `msg_id()` helpers that truncate IDs to 7 chars and apply deterministic colours based on content hash
  - `format_timestamp()` for ISO 8601-style timestamps (YYYYMMDDTHH:MM:SS.mmm)
  - Colour palette with 12 distinct ANSI colours for visual differentiation of IDs

- **Updated binaries**:
  - `src/bin/relay.rs`: Call `logging::init()` at startup, replace `eprintln!` with `tlog!`
  - `src/bin/tenet-web.rs`: Call `logging::init()` at startup, replace all ~60 `eprintln!` calls with `tlog!`, use `peer_id()` and `msg_id()` helpers for consistent ID formatting

- **Updated modules**:
  - `src/identity.rs`: Replace `eprintln!` with `crate::tlog!` in migration functions
  - `src/relay.rs`: Refactor `log_message()` to use `logging::format_timestamp()`, reuse `peer_id()` and `msg_id()` helpers
  - `src/storage.rs`: Fix profile upsert logic to allow same-timestamp updates (enables richer friends-only profiles to overwrite public-only ones)

## Implementation Details

- Colours are only applied when stderr is a terminal (detected via `IsTerminal` trait)
- Timestamps and source locations are dimmed (ANSI code `\x1b[2m`) when colours are enabled
- ID truncation is consistent across all logging: peer IDs shown as `p-1GDfZU`, message IDs as `m-a1b2c3d`
- The `tlog!` macro uses `file!()` and `line!()` to capture source location at compile time
- Deterministic colour assignment ensures the same ID always gets the same colour within a session

https://claude.ai/code/session_01MrYLe61MPb2yL46jrg3riG