### PR TITLE
Handle reaction messages in sync and update message kind

### DIFF
--- a/src/web_client/handlers/reactions.rs
+++ b/src/web_client/handlers/reactions.rs
@@ -66,7 +66,7 @@ pub async fn react_handler(
         None,
         now,
         DEFAULT_TTL_SECONDS,
-        MessageKind::Public,
+        MessageKind::Meta,
         None,
         &body_str,
         salt,


### PR DESCRIPTION
## Summary
This PR improves reaction message handling by updating the message kind classification and adding proper sync-side processing for reaction messages that don't match standard MetaMessage patterns.

## Key Changes
- Changed reaction messages from `MessageKind::Public` to `MessageKind::Meta` in the reactions handler, properly classifying them as metadata messages
- Added fallback reaction parsing logic in `sync_once()` to handle reactions that don't deserialize as standard MetaMessage objects
- Implemented storage of parsed reactions with proper error handling and logging during sync

## Implementation Details
The sync handler now attempts to parse non-standard MetaMessages as reactions by checking for `target_message_id` and `reaction` fields in the JSON payload. When a reaction is successfully identified, it's stored via `upsert_reaction()` with appropriate logging for both success and failure cases. This ensures reactions are properly persisted even if they arrive in a different format than expected.

https://claude.ai/code/session_01LiA6xUVbxuSmXP3H2RNftP