### PR TITLE
Refactor sync loop to use typed MessageHandler callbacks

### DIFF
--- a/src/bin/simulation.rs
+++ b/src/bin/simulation.rs
@@ -539,7 +539,6 @@ fn format_log_entry(entry: &LogEntry) -> Line<'static> {
     ])
 }
 
-
 fn format_duration(seconds: f64) -> String {
     let total_seconds = seconds.max(0.0).round() as u64;
     let hours = total_seconds / 3600;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod crypto;
 pub mod groups;
 pub mod identity;
 pub mod logging;
+pub mod message_handler;
 pub mod protocol;
 pub mod relay;
 pub mod relay_transport;

--- a/src/message_handler.rs
+++ b/src/message_handler.rs
@@ -1,0 +1,887 @@
+//! Protocol-level persistence for received messages.
+//!
+//! `StorageMessageHandler` implements [`MessageHandler`] and handles all
+//! standard protocol-level storage writes: messages, attachments, peer online
+//! status, friend request state machine, reactions, and profile updates.
+//!
+//! It is intentionally storage-agnostic from the caller's point of view: the
+//! caller creates a `StorageMessageHandler`, registers it on a
+//! [`RelayClient`][crate::client::RelayClient] via `set_handler()`, and calls
+//! `sync_inbox()`.  All persistence happens inside the handler callbacks.
+//!
+//! Application-specific side effects (WebSocket events, push notifications,
+//! etc.) belong in a wrapper type that delegates to `StorageMessageHandler`
+//! first, then adds its own logic.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::Engine as _;
+
+use crate::client::{ClientMessage, MessageHandler};
+use crate::crypto::StoredKeypair;
+use crate::protocol::{
+    build_envelope_from_payload, build_meta_payload, Envelope, MessageKind, MetaMessage,
+};
+use crate::relay_transport::post_envelope;
+use crate::storage::{
+    AttachmentRow, FriendRequestRow, MessageAttachmentRow, MessageRow, NotificationRow, PeerRow,
+    ProfileRow, ReactionRow, Storage,
+};
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Handles protocol-level storage writes on behalf of a sync loop.
+///
+/// Encapsulates persistence for:
+/// - `Direct`, `Public`, `FriendGroup`, and `StoreForPeer` messages
+/// - Inline attachment data
+/// - Peer online status updates
+/// - Friend request state machine (including auto-accept on mutual request)
+/// - Reaction and profile updates
+/// - Notification creation for direct messages, replies, and reactions
+pub struct StorageMessageHandler {
+    storage: Storage,
+    keypair: StoredKeypair,
+    relay_url: Option<String>,
+    my_peer_id: String,
+}
+
+impl StorageMessageHandler {
+    /// Create a new handler.
+    ///
+    /// * `storage` — SQLite storage to write into.
+    /// * `keypair` — Local keypair; used to sign outgoing envelopes (e.g.
+    ///   auto-accept friend requests).
+    /// * `relay_url` — Relay to post replies to.  `None` disables outgoing
+    ///   posts (reactions, auto-accepts, etc. are still stored locally).
+    pub fn new(storage: Storage, keypair: StoredKeypair, relay_url: Option<String>) -> Self {
+        let my_peer_id = keypair.id.clone();
+        Self {
+            storage,
+            keypair,
+            relay_url,
+            my_peer_id,
+        }
+    }
+
+    /// Borrow the underlying storage.
+    pub fn storage(&self) -> &Storage {
+        &self.storage
+    }
+
+    /// Borrow the underlying storage mutably.
+    pub fn storage_mut(&mut self) -> &mut Storage {
+        &mut self.storage
+    }
+
+    /// Consume the handler and return the underlying storage.
+    pub fn into_storage(self) -> Storage {
+        self.storage
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    fn message_kind_str(kind: &MessageKind) -> &'static str {
+        match kind {
+            MessageKind::Public => "public",
+            MessageKind::Direct => "direct",
+            MessageKind::FriendGroup => "friend_group",
+            MessageKind::Meta => "meta",
+            MessageKind::StoreForPeer => "store_for_peer",
+        }
+    }
+
+    fn process_friend_request(
+        &mut self,
+        from_peer_id: &str,
+        signing_public_key: &str,
+        encryption_public_key: &str,
+        message: Option<String>,
+        now: u64,
+    ) {
+        crate::tlog!(
+            "handler: received friend_request from {}",
+            crate::logging::peer_id(from_peer_id)
+        );
+
+        // If already friends, treat as duplicate and skip.
+        if let Ok(Some(peer)) = self.storage.get_peer(from_peer_id) {
+            if peer.is_friend {
+                crate::tlog!(
+                    "handler: friend request from {} is a duplicate (already friends), ignoring",
+                    crate::logging::peer_id(from_peer_id)
+                );
+                return;
+            }
+        }
+
+        // Check if we have a pending OUTGOING request to this peer (mutual / race condition).
+        let outgoing = self
+            .storage
+            .find_request_between(&self.my_peer_id, from_peer_id)
+            .unwrap_or(None);
+
+        if let Some(ref out_req) = outgoing {
+            if out_req.status == "pending" {
+                // Auto-accept: mark our outgoing as accepted, add them as a friend,
+                // and send a FriendAccept envelope back.
+                crate::tlog!(
+                    "handler: mutual friend request detected with {} — auto-accepting",
+                    crate::logging::peer_id(from_peer_id)
+                );
+                let _ = self
+                    .storage
+                    .update_friend_request_status(out_req.id, "accepted");
+
+                let peer_row = PeerRow {
+                    peer_id: from_peer_id.to_string(),
+                    display_name: None,
+                    signing_public_key: signing_public_key.to_string(),
+                    encryption_public_key: Some(encryption_public_key.to_string()),
+                    added_at: now,
+                    is_friend: true,
+                    last_seen_online: Some(now),
+                    online: false,
+                };
+                let _ = self.storage.insert_peer(&peer_row);
+
+                // Post FriendAccept so the other peer completes the handshake.
+                self.post_friend_accept(from_peer_id, now);
+                return;
+            }
+        }
+
+        // Check for an existing incoming request from this peer.
+        let existing = self
+            .storage
+            .find_request_between(from_peer_id, &self.my_peer_id)
+            .unwrap_or(None);
+
+        if let Some(ref ex) = existing {
+            if ex.status == "blocked" || ex.status == "ignored" {
+                crate::tlog!(
+                    "handler: friend request from {} is {}, not resurfacing",
+                    crate::logging::peer_id(from_peer_id),
+                    ex.status
+                );
+                return;
+            }
+            if ex.status == "pending" {
+                let _ = self.storage.refresh_friend_request(
+                    ex.id,
+                    message.as_deref(),
+                    signing_public_key,
+                    encryption_public_key,
+                );
+                return;
+            }
+            if ex.status == "accepted" {
+                crate::tlog!(
+                    "handler: friend request from {} already accepted, skipping",
+                    crate::logging::peer_id(from_peer_id)
+                );
+                return;
+            }
+        }
+
+        // No existing request — create a new one.
+        let fr_row = FriendRequestRow {
+            id: 0,
+            from_peer_id: from_peer_id.to_string(),
+            to_peer_id: self.my_peer_id.clone(),
+            status: "pending".to_string(),
+            message: message.clone(),
+            from_signing_key: signing_public_key.to_string(),
+            from_encryption_key: encryption_public_key.to_string(),
+            direction: "incoming".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        match self.storage.insert_friend_request(&fr_row) {
+            Ok(request_id) => {
+                // Create notification for the new friend request.
+                let notif = NotificationRow {
+                    id: 0,
+                    notification_type: "friend_request".to_string(),
+                    message_id: format!("friend_request_{request_id}"),
+                    sender_id: from_peer_id.to_string(),
+                    created_at: now,
+                    seen: false,
+                    read: false,
+                };
+                let _ = self.storage.insert_notification(&notif);
+                crate::tlog!(
+                    "handler: stored incoming friend request from {} (id={})",
+                    crate::logging::peer_id(from_peer_id),
+                    request_id
+                );
+            }
+            Err(e) => {
+                crate::tlog!(
+                    "handler: failed to store friend request from {}: {}",
+                    crate::logging::peer_id(from_peer_id),
+                    e
+                );
+            }
+        }
+    }
+
+    fn process_friend_accept(
+        &mut self,
+        from_peer_id: &str,
+        signing_public_key: String,
+        encryption_public_key: String,
+        now: u64,
+    ) {
+        crate::tlog!(
+            "handler: received friend_accept from {}",
+            crate::logging::peer_id(from_peer_id)
+        );
+
+        if let Ok(Some(peer)) = self.storage.get_peer(from_peer_id) {
+            if peer.is_friend {
+                crate::tlog!(
+                    "handler: friend_accept from {} is a duplicate (already friends), ignoring",
+                    crate::logging::peer_id(from_peer_id)
+                );
+                return;
+            }
+        }
+
+        let requests = self
+            .storage
+            .list_friend_requests(Some("pending"), Some("outgoing"))
+            .unwrap_or_default();
+        if let Some(pending) = requests.iter().find(|r| r.to_peer_id == from_peer_id) {
+            let req_id = pending.id;
+            let _ = self
+                .storage
+                .update_friend_request_status(req_id, "accepted");
+            let peer_row = PeerRow {
+                peer_id: from_peer_id.to_string(),
+                display_name: None,
+                signing_public_key,
+                encryption_public_key: Some(encryption_public_key),
+                added_at: now,
+                is_friend: true,
+                last_seen_online: Some(now),
+                online: false,
+            };
+            let _ = self.storage.insert_peer(&peer_row);
+
+            // Archive any incoming request from this peer (race condition).
+            if let Ok(Some(incoming)) = self
+                .storage
+                .find_request_between(from_peer_id, &self.my_peer_id)
+            {
+                if incoming.status == "pending" {
+                    let _ = self
+                        .storage
+                        .update_friend_request_status(incoming.id, "accepted");
+                }
+            }
+
+            crate::tlog!(
+                "handler: friend request accepted by {} (id={})",
+                crate::logging::peer_id(from_peer_id),
+                req_id
+            );
+        } else {
+            crate::tlog!(
+                "handler: received friend_accept from {} but no matching pending request",
+                crate::logging::peer_id(from_peer_id)
+            );
+        }
+    }
+
+    fn post_friend_accept(&self, to_peer_id: &str, now: u64) {
+        let Some(ref relay_url) = self.relay_url else {
+            return;
+        };
+        let meta_msg = MetaMessage::FriendAccept {
+            peer_id: self.keypair.id.clone(),
+            signing_public_key: self.keypair.signing_public_key_hex.clone(),
+            encryption_public_key: self.keypair.public_key_hex.clone(),
+        };
+        let Ok(payload) = build_meta_payload(&meta_msg) else {
+            return;
+        };
+        let Ok(env) = build_envelope_from_payload(
+            self.keypair.id.clone(),
+            to_peer_id.to_string(),
+            None,
+            None,
+            now,
+            crate::web_client::config::DEFAULT_TTL_SECONDS,
+            MessageKind::Meta,
+            None,
+            None,
+            payload,
+            &self.keypair.signing_private_key_hex,
+        ) else {
+            return;
+        };
+        if let Err(e) = post_envelope(relay_url, &env) {
+            crate::tlog!(
+                "handler: failed to send auto-accept to {}: {}",
+                crate::logging::peer_id(to_peer_id),
+                e
+            );
+        } else {
+            crate::tlog!(
+                "handler: sent auto-accept to {} via relay",
+                crate::logging::peer_id(to_peer_id)
+            );
+        }
+    }
+}
+
+impl MessageHandler for StorageMessageHandler {
+    fn on_message(&mut self, envelope: &Envelope, message: &ClientMessage) {
+        let now = now_secs();
+
+        // Deduplication: skip if already stored.
+        if self
+            .storage
+            .has_message(&message.message_id)
+            .unwrap_or(true)
+        {
+            return;
+        }
+
+        // Update last_seen_online for the sender.
+        let _ = self.storage.update_peer_online(
+            &envelope.header.sender_id,
+            false,
+            envelope.header.timestamp,
+        );
+
+        let kind_str = Self::message_kind_str(&envelope.header.message_kind);
+
+        // Check for special message types that should not appear in the timeline.
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&message.body) {
+            let msg_type = parsed.get("type").and_then(|t| t.as_str());
+            if msg_type == Some("tenet.profile") {
+                // Store as a profile update rather than a regular message.
+                self.store_profile_from_json(
+                    &envelope.header.sender_id,
+                    &envelope.header.timestamp,
+                    &parsed,
+                );
+                return;
+            }
+            if msg_type == Some("group_key_distribution") {
+                // Group key distribution messages are not stored as timeline messages.
+                return;
+            }
+        }
+
+        let row = MessageRow {
+            message_id: message.message_id.clone(),
+            sender_id: message.sender_id.clone(),
+            recipient_id: self.my_peer_id.clone(),
+            message_kind: kind_str.to_string(),
+            group_id: envelope.header.group_id.clone(),
+            body: Some(message.body.clone()),
+            timestamp: message.timestamp,
+            received_at: now,
+            ttl_seconds: envelope.header.ttl_seconds,
+            is_read: false,
+            raw_envelope: None,
+            reply_to: envelope.header.reply_to.clone(),
+        };
+
+        if self.storage.insert_message(&row).is_ok() {
+            // Store any inline attachment data so it can be served locally.
+            for (i, att_ref) in envelope.payload.attachments.iter().enumerate() {
+                if let Some(ref data_b64) = att_ref.data {
+                    if let Ok(data) =
+                        base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(data_b64)
+                    {
+                        let att_row = AttachmentRow {
+                            content_hash: att_ref.content_id.0.clone(),
+                            content_type: att_ref.content_type.clone(),
+                            size_bytes: att_ref.size,
+                            data,
+                            created_at: now,
+                        };
+                        let _ = self.storage.insert_attachment(&att_row);
+                        let _ = self
+                            .storage
+                            .insert_message_attachment(&MessageAttachmentRow {
+                                message_id: message.message_id.clone(),
+                                content_hash: att_ref.content_id.0.clone(),
+                                filename: att_ref.filename.clone(),
+                                position: i as u32,
+                            });
+                    }
+                }
+            }
+
+            // Create notification for direct messages and replies to our own messages.
+            let notification_type = if row.reply_to.is_some() {
+                if let Some(ref parent_id) = row.reply_to {
+                    if let Ok(Some(parent_msg)) = self.storage.get_message(parent_id) {
+                        if parent_msg.sender_id == self.my_peer_id {
+                            Some("reply")
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else if kind_str == "direct" {
+                Some("direct_message")
+            } else {
+                None
+            };
+
+            if let Some(notif_type) = notification_type {
+                let notif = NotificationRow {
+                    id: 0,
+                    notification_type: notif_type.to_string(),
+                    message_id: message.message_id.clone(),
+                    sender_id: message.sender_id.clone(),
+                    created_at: now,
+                    seen: false,
+                    read: false,
+                };
+                let _ = self.storage.insert_notification(&notif);
+            }
+        }
+    }
+
+    fn on_meta(&mut self, meta: &MetaMessage) {
+        let now = now_secs();
+        match meta {
+            MetaMessage::Online { peer_id, timestamp } => {
+                let _ = self.storage.update_peer_online(peer_id, true, *timestamp);
+            }
+            MetaMessage::Ack {
+                peer_id,
+                online_timestamp,
+            } => {
+                let _ = self
+                    .storage
+                    .update_peer_online(peer_id, true, *online_timestamp);
+            }
+            MetaMessage::FriendRequest {
+                peer_id,
+                signing_public_key,
+                encryption_public_key,
+                message,
+            } => {
+                self.process_friend_request(
+                    peer_id,
+                    signing_public_key,
+                    encryption_public_key,
+                    message.clone(),
+                    now,
+                );
+            }
+            MetaMessage::FriendAccept {
+                peer_id,
+                signing_public_key,
+                encryption_public_key,
+            } => {
+                self.process_friend_accept(
+                    peer_id,
+                    signing_public_key.clone(),
+                    encryption_public_key.clone(),
+                    now,
+                );
+            }
+            MetaMessage::MessageRequest { .. } => {
+                // Not handled at the storage layer.
+            }
+        }
+    }
+
+    fn on_raw_meta(&mut self, envelope: &Envelope, body: &str) {
+        let now = now_secs();
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+            // Reactions: {"target_message_id": "...", "reaction": "upvote"|"downvote"}
+            if let (Some(target_id), Some(reaction)) = (
+                parsed.get("target_message_id").and_then(|v| v.as_str()),
+                parsed.get("reaction").and_then(|v| v.as_str()),
+            ) {
+                let reaction_row = ReactionRow {
+                    message_id: envelope.header.message_id.0.clone(),
+                    target_id: target_id.to_string(),
+                    sender_id: envelope.header.sender_id.clone(),
+                    reaction: reaction.to_string(),
+                    timestamp: envelope.header.timestamp,
+                };
+                match self.storage.upsert_reaction(&reaction_row) {
+                    Err(e) => {
+                        crate::tlog!(
+                            "handler: failed to store reaction from {}: {}",
+                            crate::logging::peer_id(&envelope.header.sender_id),
+                            e
+                        );
+                    }
+                    Ok(()) => {
+                        crate::tlog!(
+                            "handler: received {} reaction from {} for message {}",
+                            reaction,
+                            crate::logging::peer_id(&envelope.header.sender_id),
+                            crate::logging::msg_id(target_id)
+                        );
+
+                        // Create a notification if the reaction is to one of our own messages.
+                        if let Ok(Some(target_msg)) = self.storage.get_message(target_id) {
+                            if target_msg.sender_id == self.my_peer_id {
+                                let notif = NotificationRow {
+                                    id: 0,
+                                    notification_type: "reaction".to_string(),
+                                    message_id: envelope.header.message_id.0.clone(),
+                                    sender_id: envelope.header.sender_id.clone(),
+                                    created_at: now,
+                                    seen: false,
+                                    read: false,
+                                };
+                                let _ = self.storage.insert_notification(&notif);
+                            }
+                        }
+                    }
+                }
+                return;
+            }
+
+            // Profile updates embedded in raw meta (legacy / forwarded).
+            if parsed.get("type").and_then(|t| t.as_str()) == Some("tenet.profile") {
+                self.store_profile_from_json(
+                    &envelope.header.sender_id,
+                    &envelope.header.timestamp,
+                    &parsed,
+                );
+            }
+        }
+    }
+}
+
+impl StorageMessageHandler {
+    fn store_profile_from_json(
+        &mut self,
+        sender_id: &str,
+        header_timestamp: &u64,
+        parsed: &serde_json::Value,
+    ) {
+        let profile_user_id = parsed
+            .get("user_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or(sender_id)
+            .to_string();
+        let updated_at = parsed
+            .get("updated_at")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(*header_timestamp);
+
+        let profile_row = ProfileRow {
+            user_id: profile_user_id.clone(),
+            display_name: parsed
+                .get("display_name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            bio: parsed
+                .get("bio")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            avatar_hash: parsed
+                .get("avatar_hash")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            public_fields: parsed
+                .get("public_fields")
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "{}".to_string()),
+            friends_fields: parsed
+                .get("friends_fields")
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "{}".to_string()),
+            updated_at,
+        };
+
+        match self.storage.upsert_profile_if_newer(&profile_row) {
+            Ok(true) => {
+                crate::tlog!(
+                    "handler: updated profile for {}",
+                    crate::logging::peer_id(&profile_user_id)
+                );
+                // Mirror display name into the peer row if it changed.
+                if let Some(ref display_name) = profile_row.display_name {
+                    if let Ok(Some(mut peer)) = self.storage.get_peer(&profile_user_id) {
+                        if peer.display_name.as_deref() != Some(display_name) {
+                            peer.display_name = Some(display_name.clone());
+                            let _ = self.storage.insert_peer(&peer);
+                        }
+                    }
+                }
+            }
+            Ok(false) => {}
+            Err(e) => {
+                crate::tlog!(
+                    "handler: failed to update profile for {}: {}",
+                    crate::logging::peer_id(&profile_user_id),
+                    e
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::generate_keypair;
+    use crate::protocol::{build_plaintext_envelope, MessageKind, MetaMessage};
+    use crate::storage::Storage;
+
+    fn open_memory_storage() -> Storage {
+        Storage::open_in_memory(std::path::Path::new("/tmp")).expect("in-memory storage")
+    }
+
+    #[test]
+    fn handler_stores_direct_message() {
+        let alice = generate_keypair();
+        let bob = generate_keypair();
+
+        let mut storage = open_memory_storage();
+        // Register Alice as a peer in Bob's storage.
+        let peer_row = PeerRow {
+            peer_id: alice.id.clone(),
+            display_name: None,
+            signing_public_key: alice.signing_public_key_hex.clone(),
+            encryption_public_key: Some(alice.public_key_hex.clone()),
+            added_at: 0,
+            is_friend: true,
+            last_seen_online: None,
+            online: false,
+        };
+        storage.insert_peer(&peer_row).expect("insert peer");
+
+        let mut handler = StorageMessageHandler::new(storage, bob.clone(), None);
+
+        // Build a simple plaintext direct message from Alice to Bob.
+        let salt = [0u8; 16];
+        let envelope = build_plaintext_envelope(
+            &alice.id,
+            &bob.id,
+            None,
+            None,
+            1_700_000_000,
+            3600,
+            MessageKind::Direct,
+            None,
+            None,
+            "hello from alice",
+            salt,
+            &alice.signing_private_key_hex,
+        )
+        .expect("build envelope");
+
+        let message = ClientMessage {
+            message_id: envelope.header.message_id.0.clone(),
+            sender_id: alice.id.clone(),
+            timestamp: envelope.header.timestamp,
+            body: "hello from alice".to_string(),
+        };
+
+        handler.on_message(&envelope, &message);
+
+        let stored = handler
+            .storage()
+            .get_message(&message.message_id)
+            .expect("get message")
+            .expect("message exists");
+        assert_eq!(stored.sender_id, alice.id);
+        assert_eq!(stored.body, Some("hello from alice".to_string()));
+
+        // Check that a direct_message notification was created.
+        let notifs = handler
+            .storage()
+            .list_notifications(false, 100)
+            .expect("list notifications");
+        assert_eq!(notifs.len(), 1);
+        assert_eq!(notifs[0].notification_type, "direct_message");
+    }
+
+    #[test]
+    fn handler_deduplicates_messages() {
+        let alice = generate_keypair();
+        let bob = generate_keypair();
+
+        let storage = open_memory_storage();
+        let mut handler = StorageMessageHandler::new(storage, bob.clone(), None);
+
+        let salt = [0u8; 16];
+        let envelope = build_plaintext_envelope(
+            &alice.id,
+            &bob.id,
+            None,
+            None,
+            1_700_000_000,
+            3600,
+            MessageKind::Direct,
+            None,
+            None,
+            "dedup test",
+            salt,
+            &alice.signing_private_key_hex,
+        )
+        .expect("build envelope");
+
+        let message = ClientMessage {
+            message_id: envelope.header.message_id.0.clone(),
+            sender_id: alice.id.clone(),
+            timestamp: envelope.header.timestamp,
+            body: "dedup test".to_string(),
+        };
+
+        handler.on_message(&envelope, &message);
+        handler.on_message(&envelope, &message); // second call should be a no-op
+
+        let all_msgs = handler
+            .storage()
+            .list_messages(None, None, None, 100)
+            .expect("list messages");
+        assert_eq!(all_msgs.len(), 1, "should only store message once");
+    }
+
+    #[test]
+    fn handler_updates_peer_online_on_meta() {
+        let alice = generate_keypair();
+        let bob = generate_keypair();
+
+        let mut storage = open_memory_storage();
+        let peer_row = PeerRow {
+            peer_id: alice.id.clone(),
+            display_name: None,
+            signing_public_key: alice.signing_public_key_hex.clone(),
+            encryption_public_key: None,
+            added_at: 0,
+            is_friend: false,
+            last_seen_online: None,
+            online: false,
+        };
+        storage.insert_peer(&peer_row).expect("insert peer");
+
+        let mut handler = StorageMessageHandler::new(storage, bob.clone(), None);
+
+        let meta = MetaMessage::Online {
+            peer_id: alice.id.clone(),
+            timestamp: 1_700_000_100,
+        };
+        handler.on_meta(&meta);
+
+        let peer = handler
+            .storage()
+            .get_peer(&alice.id)
+            .expect("get peer")
+            .expect("peer exists");
+        assert!(peer.online);
+        assert_eq!(peer.last_seen_online, Some(1_700_000_100));
+    }
+
+    #[test]
+    fn handler_stores_reaction_and_creates_notification() {
+        let alice = generate_keypair();
+        let bob = generate_keypair();
+
+        let mut storage = open_memory_storage();
+        let peer_row = PeerRow {
+            peer_id: alice.id.clone(),
+            display_name: None,
+            signing_public_key: alice.signing_public_key_hex.clone(),
+            encryption_public_key: None,
+            added_at: 0,
+            is_friend: true,
+            last_seen_online: None,
+            online: false,
+        };
+        storage.insert_peer(&peer_row).expect("insert peer");
+
+        // Pre-insert a message authored by Bob.
+        let target_msg = MessageRow {
+            message_id: "target-msg-001".to_string(),
+            sender_id: bob.id.clone(),
+            recipient_id: "*".to_string(),
+            message_kind: "public".to_string(),
+            group_id: None,
+            body: Some("a public post".to_string()),
+            timestamp: 1_700_000_000,
+            received_at: 1_700_000_000,
+            ttl_seconds: 3600,
+            is_read: false,
+            raw_envelope: None,
+            reply_to: None,
+        };
+        storage.insert_message(&target_msg).expect("insert target");
+
+        let mut handler = StorageMessageHandler::new(storage, bob.clone(), None);
+
+        // Build a raw-meta reaction envelope from Alice.
+        let reaction_body = r#"{"target_message_id":"target-msg-001","reaction":"upvote"}"#;
+        let salt = [0u8; 16];
+        let envelope = build_plaintext_envelope(
+            &alice.id,
+            "*",
+            None,
+            None,
+            1_700_000_200,
+            3600,
+            MessageKind::Meta,
+            None,
+            None,
+            reaction_body,
+            salt,
+            &alice.signing_private_key_hex,
+        )
+        .expect("build reaction envelope");
+
+        handler.on_raw_meta(&envelope, reaction_body);
+
+        // Reaction should be stored.
+        let reactions = handler
+            .storage()
+            .list_reactions("target-msg-001")
+            .expect("list reactions");
+        assert_eq!(reactions.len(), 1);
+        assert_eq!(reactions[0].reaction, "upvote");
+
+        // Notification should be created (Alice reacted to Bob's own message).
+        let notifs = handler
+            .storage()
+            .list_notifications(false, 100)
+            .expect("list notifications");
+        assert_eq!(notifs.len(), 1);
+        assert_eq!(notifs[0].notification_type, "reaction");
+    }
+
+    #[test]
+    fn sync_event_outcome_message_variant() {
+        use crate::client::SyncEventOutcome;
+        let msg = ClientMessage {
+            message_id: "id".to_string(),
+            sender_id: "s".to_string(),
+            timestamp: 0,
+            body: "body".to_string(),
+        };
+        let outcome = SyncEventOutcome::Message(msg.clone());
+        if let SyncEventOutcome::Message(m) = outcome {
+            assert_eq!(m.body, "body");
+        } else {
+            panic!("expected Message variant");
+        }
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -271,12 +271,12 @@ impl Storage {
     pub fn open(path: &Path) -> Result<Self, StorageError> {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
-        let attachment_dir = path
-            .parent()
-            .unwrap_or(Path::new("."))
-            .join("attachments");
+        let attachment_dir = path.parent().unwrap_or(Path::new(".")).join("attachments");
         std::fs::create_dir_all(&attachment_dir)?;
-        let storage = Self { conn, attachment_dir };
+        let storage = Self {
+            conn,
+            attachment_dir,
+        };
         storage.create_schema()?;
         Ok(storage)
     }
@@ -1786,10 +1786,9 @@ impl Storage {
 
     /// Mark all notifications as read.
     pub fn mark_all_notifications_read(&self) -> Result<u32, StorageError> {
-        let affected = self.conn.execute(
-            "UPDATE notifications SET read = 1 WHERE read = 0",
-            [],
-        )?;
+        let affected = self
+            .conn
+            .execute("UPDATE notifications SET read = 1 WHERE read = 0", [])?;
         Ok(affected as u32)
     }
 
@@ -1815,15 +1814,18 @@ impl Storage {
 
     /// Mark all notifications as seen (user opened the notification panel).
     pub fn mark_all_notifications_seen(&self) -> Result<u32, StorageError> {
-        let affected = self.conn.execute(
-            "UPDATE notifications SET seen = 1 WHERE seen = 0",
-            [],
-        )?;
+        let affected = self
+            .conn
+            .execute("UPDATE notifications SET seen = 1 WHERE seen = 0", [])?;
         Ok(affected as u32)
     }
 
     /// Check if a notification already exists (to avoid duplicates).
-    pub fn has_notification(&self, notification_type: &str, message_id: &str) -> Result<bool, StorageError> {
+    pub fn has_notification(
+        &self,
+        notification_type: &str,
+        message_id: &str,
+    ) -> Result<bool, StorageError> {
         let count: i64 = self.conn.query_row(
             "SELECT COUNT(*) FROM notifications WHERE type = ?1 AND message_id = ?2",
             params![notification_type, message_id],
@@ -2056,7 +2058,11 @@ fn dirs_or_default() -> PathBuf {
 /// Map a MIME content type to a lowercase file extension.
 /// Used to construct attachment filenames on disk.
 fn content_type_to_ext(content_type: &str) -> &str {
-    let base = content_type.split(';').next().unwrap_or(content_type).trim();
+    let base = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim();
     match base {
         "image/png" => "png",
         "image/jpeg" | "image/jpg" => "jpg",

--- a/src/web_client/handlers/health.rs
+++ b/src/web_client/handlers/health.rs
@@ -44,7 +44,10 @@ pub async fn sync_now_handler(State(state): State<SharedState>) -> impl IntoResp
                     relay_url,
                 });
             }
-            (StatusCode::OK, axum::Json(serde_json::json!({"status": "ok"})))
+            (
+                StatusCode::OK,
+                axum::Json(serde_json::json!({"status": "ok"})),
+            )
         }
         Err(e) => {
             let st = state.lock().await;

--- a/src/web_client/handlers/messages.rs
+++ b/src/web_client/handlers/messages.rs
@@ -393,11 +393,10 @@ pub async fn send_group_handler(
 
     // Build envelope (CPU-only, no lock needed)
     let aad = req.group_id.as_bytes();
-    let mut payload =
-        match build_group_message_payload(req.body.as_bytes(), &group_key, aad) {
-            Ok(p) => p,
-            Err(e) => return api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("crypto: {e}")),
-        };
+    let mut payload = match build_group_message_payload(req.body.as_bytes(), &group_key, aad) {
+        Ok(p) => p,
+        Err(e) => return api_error(StatusCode::INTERNAL_SERVER_ERROR, format!("crypto: {e}")),
+    };
     payload.attachments = attachment_refs;
 
     let envelope = match build_envelope_from_payload(
@@ -517,8 +516,7 @@ fn build_attachment_refs(
         .iter()
         .filter_map(|att| {
             let row = storage.get_attachment(&att.content_hash).ok()??;
-            let data_b64 =
-                base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&row.data);
+            let data_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&row.data);
             Some(AttachmentRef {
                 content_id: ContentId(row.content_hash),
                 content_type: row.content_type,

--- a/src/web_client/handlers/notifications.rs
+++ b/src/web_client/handlers/notifications.rs
@@ -61,10 +61,7 @@ pub async fn count_notifications_handler(State(state): State<SharedState>) -> Re
 }
 
 /// POST /api/notifications/:id/read - Mark a notification as read.
-pub async fn mark_read_handler(
-    State(state): State<SharedState>,
-    Path(id): Path<i64>,
-) -> Response {
+pub async fn mark_read_handler(State(state): State<SharedState>, Path(id): Path<i64>) -> Response {
     let st = state.lock().await;
 
     match st.storage.mark_notification_read(id) {

--- a/tests/client_sync_tests.rs
+++ b/tests/client_sync_tests.rs
@@ -1,0 +1,212 @@
+//! Integration tests for the client-managed storage design:
+//!
+//! - `SyncOutcome` now contains typed `SyncEvent`s in addition to the
+//!   convenience `messages` and `errors` views.
+//! - `MessageHandler` trait allows callers to register push-style callbacks on
+//!   `RelayClient`.
+//! - `sync_inbox()` handles all message kinds (Direct, Public, FriendGroup, Meta).
+
+use tenet::client::{
+    ClientConfig, ClientEncryption, ClientMessage, MessageHandler, RelayClient, SyncEvent,
+    SyncEventOutcome,
+};
+use tenet::crypto::generate_keypair;
+use tenet::protocol::{
+    build_meta_payload, build_plaintext_envelope, decode_meta_payload, Envelope, MessageKind,
+    MetaMessage,
+};
+
+// ---------------------------------------------------------------------------
+// Helper: a simple in-process MessageHandler that records every callback
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct RecordingHandler {
+    messages: Vec<ClientMessage>,
+    meta_messages: Vec<MetaMessage>,
+    raw_metas: Vec<String>,
+    rejected: Vec<String>,
+}
+
+impl MessageHandler for RecordingHandler {
+    fn on_message(&mut self, _envelope: &Envelope, message: &ClientMessage) {
+        self.messages.push(message.clone());
+    }
+
+    fn on_meta(&mut self, meta: &MetaMessage) {
+        self.meta_messages.push(meta.clone());
+    }
+
+    fn on_raw_meta(&mut self, _envelope: &Envelope, body: &str) {
+        self.raw_metas.push(body.to_string());
+    }
+
+    fn on_rejected(&mut self, _envelope: &Envelope, reason: &str) {
+        self.rejected.push(reason.to_string());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests for SyncEventOutcome variants (without a live relay)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sync_event_outcome_variants_exist() {
+    // Smoke test: verify all variants can be constructed.
+    let msg = ClientMessage {
+        message_id: "id1".to_string(),
+        sender_id: "alice".to_string(),
+        timestamp: 0,
+        body: "hello".to_string(),
+    };
+    let _m = SyncEventOutcome::Message(msg);
+    let _dup = SyncEventOutcome::Duplicate;
+    let _ttl = SyncEventOutcome::TtlExpired;
+    let _unk = SyncEventOutcome::UnknownSender;
+    let _sig = SyncEventOutcome::InvalidSignature {
+        reason: "bad sig".to_string(),
+    };
+    let _dec = SyncEventOutcome::DecryptFailed {
+        reason: "bad dec".to_string(),
+    };
+    let _raw = SyncEventOutcome::RawMeta {
+        body: "{}".to_string(),
+    };
+}
+
+#[test]
+fn relay_client_set_and_clear_handler() {
+    let kp = generate_keypair();
+    let config = ClientConfig::new("http://localhost:9999", 3600, ClientEncryption::Plaintext);
+    let mut client = RelayClient::new(kp, config);
+
+    // Setting a handler should not panic.
+    client.set_handler(Box::new(RecordingHandler::default()));
+
+    // Clearing it should also not panic.
+    client.clear_handler();
+}
+
+#[test]
+fn relay_client_clone_drops_handler() {
+    let kp = generate_keypair();
+    let config = ClientConfig::new("http://localhost:9999", 3600, ClientEncryption::Plaintext);
+    let mut client = RelayClient::new(kp, config);
+    client.set_handler(Box::new(RecordingHandler::default()));
+
+    // Cloning should succeed and produce a client with no handler (handlers
+    // are not clonable, so the clone starts fresh).
+    let cloned = client.clone();
+    // The original still has its handler (not consumed).
+    // The clone should at least be usable:
+    assert_eq!(cloned.id(), client.id());
+}
+
+#[test]
+fn sync_outcome_messages_and_errors_are_derived_views() {
+    // Without a relay we cannot call sync_inbox(), but we can verify the
+    // SyncOutcome struct layout manually.
+    use tenet::client::SyncOutcome;
+
+    let alice = generate_keypair();
+    let msg = ClientMessage {
+        message_id: "abc".to_string(),
+        sender_id: alice.id.clone(),
+        timestamp: 1_700_000_000,
+        body: "hello".to_string(),
+    };
+    let envelope = {
+        let salt = [0u8; 16];
+        build_plaintext_envelope(
+            &alice.id,
+            "*",
+            None,
+            None,
+            1_700_000_000,
+            3600,
+            MessageKind::Public,
+            None,
+            None,
+            "hello",
+            salt,
+            &alice.signing_private_key_hex,
+        )
+        .expect("build envelope")
+    };
+
+    let outcome = SyncOutcome {
+        events: vec![SyncEvent {
+            envelope,
+            outcome: SyncEventOutcome::Message(msg.clone()),
+        }],
+        fetched: 1,
+        messages: vec![msg.clone()],
+        errors: vec![],
+    };
+
+    assert_eq!(outcome.fetched, 1);
+    assert_eq!(outcome.messages.len(), 1);
+    assert!(outcome.errors.is_empty());
+    assert_eq!(outcome.events.len(), 1);
+    if let SyncEventOutcome::Message(ref m) = outcome.events[0].outcome {
+        assert_eq!(m.body, "hello");
+    } else {
+        panic!("expected Message variant");
+    }
+}
+
+#[test]
+fn meta_message_payload_roundtrip() {
+    let meta = MetaMessage::Online {
+        peer_id: "alice-id".to_string(),
+        timestamp: 1_700_000_000,
+    };
+    let payload = build_meta_payload(&meta).expect("build meta payload");
+    let decoded = decode_meta_payload(&payload).expect("decode meta payload");
+    assert!(matches!(decoded, MetaMessage::Online { .. }));
+    if let MetaMessage::Online { peer_id, timestamp } = decoded {
+        assert_eq!(peer_id, "alice-id");
+        assert_eq!(timestamp, 1_700_000_000);
+    }
+}
+
+#[test]
+fn message_handler_trait_default_methods_are_no_ops() {
+    // A handler that uses all default implementations should not panic.
+    struct EmptyHandler;
+    impl MessageHandler for EmptyHandler {}
+
+    let alice = generate_keypair();
+    let salt = [0u8; 16];
+    let envelope = build_plaintext_envelope(
+        &alice.id,
+        "*",
+        None,
+        None,
+        1_700_000_000,
+        3600,
+        MessageKind::Public,
+        None,
+        None,
+        "test",
+        salt,
+        &alice.signing_private_key_hex,
+    )
+    .expect("build envelope");
+    let message = ClientMessage {
+        message_id: envelope.header.message_id.0.clone(),
+        sender_id: alice.id.clone(),
+        timestamp: envelope.header.timestamp,
+        body: "test".to_string(),
+    };
+    let meta = MetaMessage::Online {
+        peer_id: alice.id.clone(),
+        timestamp: 0,
+    };
+
+    let mut handler = EmptyHandler;
+    handler.on_message(&envelope, &message);
+    handler.on_meta(&meta);
+    handler.on_raw_meta(&envelope, "{}");
+    handler.on_rejected(&envelope, "some reason");
+}

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -109,7 +109,7 @@ fn header_roundtrips_and_validates_message_kinds() {
             ttl_seconds: 3_600,
             payload_size: 128,
             reply_to: None,
-        signature: None,
+            signature: None,
         };
         header.signature = Some(
             header


### PR DESCRIPTION
## Summary

This PR refactors the relay sync architecture to separate protocol-level message handling from application-specific side effects. The main changes introduce a `MessageHandler` trait for push-style event callbacks and a new `StorageMessageHandler` implementation that encapsulates all protocol-level persistence logic.

## Key Changes

- **New `MessageHandler` trait** (`src/client.rs`): Defines callbacks for `on_message()`, `on_meta()`, `on_raw_meta()`, and `on_rejected()` with default no-op implementations. Allows callers to register handlers on `RelayClient` via `set_handler()`.

- **New `StorageMessageHandler` struct** (`src/message_handler.rs`): Implements `MessageHandler` and handles all protocol-level storage writes:
  - Message and attachment persistence
  - Peer online status updates
  - Friend request state machine (including auto-accept on mutual requests)
  - Reaction and profile updates
  - Notification creation for direct messages, replies, and reactions
  - Automatic `FriendAccept` envelope posting when mutual requests are detected

- **Refactored `SyncOutcome`** (`src/client.rs`): Now includes:
  - `events: Vec<SyncEvent>` — per-envelope outcomes (duplicates, errors, successes)
  - `fetched: usize` — total envelopes fetched from relay
  - `messages` and `errors` — convenience views derived from events

- **New `SyncEvent` and `SyncEventOutcome` types** (`src/client.rs`): Provide typed outcomes for each envelope:
  - `Message(ClientMessage)` — successfully verified and decrypted
  - `Meta(MetaMessage)` — structured meta-message
  - `RawMeta { body }` — unparseable meta payload (for reactions, profiles, etc.)
  - `Duplicate`, `UnknownSender`, `InvalidSignature`, `DecryptFailed`, `TtlExpired`

- **Simplified `sync.rs`** (`src/web_client/sync.rs`): Refactored to use `RelayClient` with `StorageMessageHandler` instead of inline storage logic. The sync loop now:
  - Creates a `RelayClient` populated with peers and groups
  - Registers a `StorageMessageHandler` for automatic persistence
  - Processes events and broadcasts WebSocket notifications

- **Group key loading** (`src/groups.rs`): Added `add_group_key()` method to `GroupManager` to reconstruct minimal `GroupInfo` from stored group rows for decryption.

## Notable Implementation Details

- `StorageMessageHandler` is storage-agnostic from the caller's perspective; all persistence happens inside handler callbacks.
- Application-specific side effects (WebSocket events, push notifications) belong in a wrapper type that delegates to `StorageMessageHandler` first.
- Friend request auto-accept is triggered when a mutual request is detected (outgoing pending + incoming request).
- `RelayClient::clone()` intentionally drops handlers since `MessageHandler` is not `Clone`.
- TTL expiration is checked during sync before any other processing.
- Meta messages are processed from any sender without signature verification; non-meta messages require known peers and valid signatures.

https://claude.ai/code/session_01YZTmKYv2NJphEU4fc71LZa