### PR TITLE
Fix integer overflow in exponential backoff calculation

### DIFF
--- a/src/web_client/sync.rs
+++ b/src/web_client/sync.rs
@@ -26,7 +26,8 @@ pub async fn relay_sync_loop(state: SharedState) {
             SYNC_INTERVAL_SECS
         } else {
             // Exponential backoff: 30s * 2^failures, capped at 5 minutes
-            let backoff = SYNC_INTERVAL_SECS * 2u64.pow(consecutive_failures);
+            let backoff =
+                SYNC_INTERVAL_SECS.saturating_mul(2u64.saturating_pow(consecutive_failures));
             backoff.min(MAX_BACKOFF_SECS)
         };
 
@@ -53,8 +54,9 @@ pub async fn relay_sync_loop(state: SharedState) {
             }
             Err(e) => {
                 consecutive_failures += 1;
-                let next_retry_secs =
-                    (SYNC_INTERVAL_SECS * 2u64.pow(consecutive_failures)).min(MAX_BACKOFF_SECS);
+                let next_retry_secs = SYNC_INTERVAL_SECS
+                    .saturating_mul(2u64.saturating_pow(consecutive_failures))
+                    .min(MAX_BACKOFF_SECS);
 
                 let st = state.lock().await;
                 let was_connected = st.relay_connected.swap(false, Ordering::Relaxed);


### PR DESCRIPTION
## Summary
Replace unchecked arithmetic operations with saturating arithmetic in the exponential backoff calculation for the relay sync loop to prevent integer overflow panics.

## Key Changes
- Replaced `SYNC_INTERVAL_SECS * 2u64.pow(consecutive_failures)` with `SYNC_INTERVAL_SECS.saturating_mul(2u64.saturating_pow(consecutive_failures))` in two locations
- Applied saturating multiplication and saturating power operations to prevent overflow when calculating exponential backoff delays

## Implementation Details
The exponential backoff formula calculates delays as `30s * 2^failures` (capped at 5 minutes). With unchecked arithmetic, this could panic if `consecutive_failures` grows large enough to cause integer overflow. By using saturating operations, the calculation will gracefully cap at `u64::MAX` instead of panicking, which is then bounded by the `MAX_BACKOFF_SECS` cap anyway. This makes the retry logic more robust and prevents potential denial-of-service scenarios from repeated sync failures.

https://claude.ai/code/session_01EE9zjL5ae9xngPP2TY3EQ4