### PR TITLE
Make MessageHandler return outgoing envelopes for caller routing

### DIFF
--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -801,7 +801,10 @@ impl EventBasedHarness {
                 metrics_tracker: &mut self.metrics_tracker,
             };
 
-            client.handle_inbox(step, envelopes, &mut context, None);
+            let outcome = client.handle_inbox(step, envelopes, &mut context, None);
+            for env in outcome.outgoing {
+                let _ = post_envelope(&self.relay_base_url, &env).await;
+            }
         }
 
         // Schedule next poll if still online (default: 60 seconds)

--- a/tests/client_sync_tests.rs
+++ b/tests/client_sync_tests.rs
@@ -29,16 +29,19 @@ struct RecordingHandler {
 }
 
 impl MessageHandler for RecordingHandler {
-    fn on_message(&mut self, _envelope: &Envelope, message: &ClientMessage) {
+    fn on_message(&mut self, _envelope: &Envelope, message: &ClientMessage) -> Vec<Envelope> {
         self.messages.push(message.clone());
+        Vec::new()
     }
 
-    fn on_meta(&mut self, meta: &MetaMessage) {
+    fn on_meta(&mut self, meta: &MetaMessage) -> Vec<Envelope> {
         self.meta_messages.push(meta.clone());
+        Vec::new()
     }
 
-    fn on_raw_meta(&mut self, _envelope: &Envelope, body: &str) {
+    fn on_raw_meta(&mut self, _envelope: &Envelope, body: &str) -> Vec<Envelope> {
         self.raw_metas.push(body.to_string());
+        Vec::new()
     }
 
     fn on_rejected(&mut self, _envelope: &Envelope, reason: &str) {


### PR DESCRIPTION
## Summary
This PR refactors the `MessageHandler` trait to return `Vec<Envelope>` from its callback methods, enabling handlers to produce outgoing messages (like auto-accept replies) that the caller is responsible for routing via their transport layer. This decouples message handling from transport concerns and makes the handler more composable.

## Key Changes

- **MessageHandler trait refactoring**: Modified `on_message()`, `on_meta()`, and `on_raw_meta()` to return `Vec<Envelope>` instead of being void. Default implementations return empty vectors.

- **StorageMessageHandler updates**: 
  - Removed `relay_url` parameter from constructor (no longer posts directly)
  - Changed `process_friend_request()` to return `Option<Envelope>` instead of posting directly
  - Renamed `post_friend_accept()` to `build_friend_accept_envelope()` to reflect that it builds rather than sends
  - All handler methods now return outgoing envelopes for the caller to route

- **RelayClient integration**: Updated `sync_with_handler()` to collect outgoing envelopes from handler callbacks and post them via `post_envelope()`

- **SimulationClient updates**:
  - Removed `#[derive(Clone)]` and implemented manual `Clone` that doesn't clone the handler (handlers are not cloned)
  - Added `set_handler()` and `clear_handler()` methods for handler registration
  - Updated `handle_inbox()` to return `ClientInboxOutcome` (containing both received count and outgoing envelopes)
  - Handler callbacks now produce outgoing envelopes that are returned to the caller

- **Client trait changes**: Updated `handle_inbox()` signature to return `ClientInboxOutcome` struct instead of just `usize`

- **Simulation scenario**: Attached `StorageMessageHandler` instances to simulation clients for in-memory message persistence

- **Test updates**: Updated `RecordingHandler` test implementation to return empty vectors from callback methods

## Implementation Details

The refactoring maintains backward compatibility through default no-op implementations while enabling handlers to participate in request-response patterns (e.g., auto-accepting friend requests). The caller retains full control over transport routing, allowing the same handler to work with different transports (HTTP relay, simulation channels, etc.).

https://claude.ai/code/session_01JaUPpvDDfVF89zot7uYdHt