### PR TITLE
Fix navigation hash routing for feed and groups views

### DIFF
--- a/web/src/app.js
+++ b/web/src/app.js
@@ -1373,6 +1373,7 @@ function navToFeed() {
     showTimelineView();
     loadMessages(false);
     setActiveHeaderNav('nav-feed');
+    window.location.hash = '#/';
 }
 
 function navToGroups() {
@@ -1383,6 +1384,7 @@ function navToGroups() {
     showTimelineView();
     loadMessages(false);
     setActiveHeaderNav('nav-groups');
+    window.location.hash = '#/';
 }
 
 function navToFriends() {


### PR DESCRIPTION
## Summary
This PR fixes navigation routing by ensuring the URL hash is properly set when navigating to the feed and groups views.

## Key Changes
- Added `window.location.hash = '#/'` to the `navToFeed()` function to update the browser URL when navigating to the feed
- Added `window.location.hash = '#/'` to the `navToGroups()` function to update the browser URL when navigating to groups

## Implementation Details
The changes ensure that the browser's address bar is updated with the correct hash route (`#/`) when users navigate to these primary views. This maintains consistency between the application state and the URL, enabling proper browser history management and allowing users to bookmark or share the correct URLs for these views.

https://claude.ai/code/session_01DQNNtoBwmZmfT1uRRCDVpa