### PR TITLE
Add comprehensive Mermaid flow diagrams for all protocol flows

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,8 @@ inner envelope that only the storage peer can decrypt while it holds the message
 
 ## Protocol Flows
 
+> Mermaid sequence diagrams for all major flows are in [docs/flows/](flows/README.md).
+
 ### Send
 
 1. Sender composes payload and selects recipients.
@@ -108,6 +110,8 @@ inner envelope that only the storage peer can decrypt while it holds the message
 3. Keep latest-seen metadata (e.g., most recent relay source) for diagnostics.
 
 ### Peer Store-and-Forward
+
+See [flows/04-store-and-forward.md](flows/04-store-and-forward.md) for the full sequence diagram.
 
 1. Sender selects a mutual friend `C` when recipient `B` is offline.
 2. Sender builds a normal direct envelope for `B`.

--- a/docs/flows/01-add-friend.md
+++ b/docs/flows/01-add-friend.md
@@ -1,0 +1,90 @@
+# Flow: Add Friend (Key Exchange Handshake)
+
+Adding a friend establishes a mutual cryptographic relationship. Both peers
+exchange their long-term signing and encryption public keys so that future
+messages can be authenticated and end-to-end encrypted.
+
+The initial request is sent **in plaintext** because the initiator does not yet
+have the recipient's encryption key. After the handshake both peers have each
+other's X25519 encryption keys and can use HPKE for all subsequent messages.
+
+See [friend_requests.md](../friend_requests.md) for the full security analysis.
+
+## Happy Path
+
+```mermaid
+sequenceDiagram
+    participant I as Initiator
+    participant R as Relay
+    participant Rc as Recipient
+
+    Note over I: Knows only Recipient's Peer ID
+
+    rect rgb(235, 245, 255)
+        Note over I,R: Step 1 – Send friend request
+        I->>I: Build FriendRequest MetaMessage<br/>(signing_key, encryption_key, message?)
+        I->>I: Sign header with Ed25519
+        I->>R: POST /envelopes<br/>{kind: Meta, recipient: Recipient}
+        R->>R: Store in Recipient's inbox
+        R-->>I: 200 OK
+    end
+
+    rect rgb(240, 255, 240)
+        Note over R,Rc: Step 2 – Recipient reviews
+        Rc->>R: GET /inbox/{recipient_peer_id}
+        R-->>Rc: [FriendRequest envelope]
+        Rc->>Rc: Verify Ed25519 signature<br/>using signing_key in request
+        Rc->>Rc: Store pending FriendRequestRow
+        Note over Rc: UI shows Accept / Ignore / Block
+    end
+
+    rect rgb(255, 245, 230)
+        Note over Rc,R: Step 3 – Accept and respond
+        Rc->>Rc: Store Initiator's keys in peers table
+        Rc->>Rc: Build FriendAccept MetaMessage<br/>(own signing_key, encryption_key)
+        Rc->>Rc: Sign header with Ed25519
+        Rc->>R: POST /envelopes<br/>{kind: Meta, recipient: Initiator}
+        R->>R: Store in Initiator's inbox
+        R-->>Rc: 200 OK
+    end
+
+    rect rgb(255, 240, 255)
+        Note over R,I: Step 4 – Initiator completes connection
+        I->>R: GET /inbox/{initiator_peer_id}
+        R-->>I: [FriendAccept envelope]
+        I->>I: Verify Ed25519 signature<br/>using signing_key in acceptance
+        I->>I: Store Recipient's keys in peers table
+        I->>I: Mark friend request as accepted
+    end
+
+    Note over I,Rc: Both peers now hold each other's<br/>X25519 encryption keys.<br/>All future messages use HPKE + ChaCha20Poly1305.
+```
+
+## Block / Ignore Variants
+
+```mermaid
+sequenceDiagram
+    participant I as Initiator
+    participant R as Relay
+    participant Rc as Recipient
+
+    I->>R: POST /envelopes (FriendRequest)
+    R-->>Rc: delivered to inbox
+
+    alt Recipient ignores
+        Note over Rc: Status set to "ignored"<br/>No response sent<br/>Request revisitable later
+    else Recipient blocks
+        Note over Rc: Status set to "blocked"<br/>Future requests auto-rejected<br/>Sender gets no notification
+    end
+
+    Note over I: Request stays "pending" from Initiator's view<br/>No indication of ignore or block
+```
+
+## Security Notes
+
+| Property | Detail |
+|---|---|
+| Friend request content | **Plaintext** — relay can see who is friending whom |
+| Public key trust | TOFU (Trust on First Use) — recipient trusts keys in the request |
+| Peer ID binding | `SHA-256(signing_public_key)` — cannot forge a matching key |
+| Post-handshake messages | HPKE-encrypted — relay cannot read content |

--- a/docs/flows/02-peer-reconnect.md
+++ b/docs/flows/02-peer-reconnect.md
@@ -1,0 +1,101 @@
+# Flow: Peer Reconnect
+
+When a peer comes back online (after a restart or a period of being offline) it
+performs several actions to re-join the network: it announces its presence to
+known peers, fetches any queued messages from the relay, and issues mesh queries
+to catch up on public content it may have missed.
+
+## Startup Sequence
+
+```mermaid
+sequenceDiagram
+    participant P as Peer (coming online)
+    participant R as Relay
+    participant F1 as Friend A
+    participant F2 as Friend B
+
+    Note over P: Peer starts up / reconnects
+
+    rect rgb(235, 245, 255)
+        Note over P,R: 1 – Online announcement
+        loop For each known peer
+            P->>P: Build MetaMessage::Online<br/>{peer_id, timestamp}
+            P->>P: Sign envelope header
+            P->>R: POST /envelopes<br/>{kind: Meta, recipient: Friend}
+            R->>R: Store in friend's inbox
+        end
+    end
+
+    rect rgb(240, 255, 240)
+        Note over P,R: 2 – Open WebSocket for real-time push
+        P->>R: GET /ws/{peer_id}?token=<auth>
+        R-->>P: 101 Switching Protocols
+        P->>R: {"type":"hello", "version":"..."}
+        Note over P,R: Relay pushes new envelopes immediately<br/>instead of waiting for next poll
+    end
+
+    rect rgb(255, 245, 230)
+        Note over P,R: 3 – Poll inbox for queued messages
+        P->>R: GET /inbox/{peer_id}
+        R-->>P: [all queued envelopes]
+        loop For each envelope
+            P->>P: Check dedup index
+            P->>P: Verify Ed25519 signature
+            P->>P: Decrypt payload (HPKE + ChaCha20)
+            P->>P: Store in SQLite
+            P->>P: Broadcast WsEvent to browser
+        end
+    end
+
+    rect rgb(255, 240, 255)
+        Note over P,R: 4 – Mesh queries for missed public content
+        loop For each known peer (rate-limited)
+            P->>P: Build MetaMessage::MessageRequest<br/>{peer_id, since_timestamp}
+            P->>R: POST /envelopes → Friend A
+        end
+    end
+
+    rect rgb(245, 235, 255)
+        Note over P,R: 5 – Profile refresh requests
+        loop For peers with stale/missing profiles
+            P->>P: Build MetaMessage::ProfileRequest
+            P->>R: POST /envelopes → Friend
+        end
+    end
+
+    Note over F1: Receives Online MetaMessage
+    F1->>F1: Update peers.online = true<br/>Record last_seen_online timestamp
+    F1->>F1: Broadcast WsEvent::PeerOnline to browser
+
+    Note over F2: Also receives Online MetaMessage
+    F2->>F2: Update peer status
+```
+
+## WebSocket-Accelerated Delivery
+
+The relay WebSocket connection (`/ws/{peer_id}`) allows near-real-time message
+delivery without waiting for the next polling interval.
+
+```mermaid
+sequenceDiagram
+    participant S as Sender
+    participant R as Relay
+    participant P as Peer (online)
+    participant UI as Browser UI
+
+    S->>R: POST /envelopes (new message)
+    R->>R: Store in Peer's inbox
+    R->>P: Push notification over WebSocket
+    Note over P: Wakes sync loop immediately
+    P->>R: GET /inbox/{peer_id}
+    R-->>P: [new envelope]
+    P->>P: Decrypt + store
+    P->>UI: WsEvent::NewMessage
+    UI->>UI: Display message
+```
+
+## Sync Loop Backoff
+
+If the relay is unreachable the sync loop backs off exponentially (30 s, 60 s,
+120 s … up to 5 minutes). Once reconnected it broadcasts
+`WsEvent::RelayStatus { connected: true }` to update the browser UI.

--- a/docs/flows/03-direct-message.md
+++ b/docs/flows/03-direct-message.md
@@ -1,0 +1,89 @@
+# Flow: Direct Message
+
+Direct messages are end-to-end encrypted using HPKE (Hybrid Public Key
+Encryption). Each message gets a fresh random content key so that compromising
+one message does not expose others. The relay handles opaque encrypted blobs and
+never has access to plaintext.
+
+Both peers must have completed the [friend request handshake](01-add-friend.md)
+before sending encrypted direct messages, because the sender needs the
+recipient's X25519 encryption public key.
+
+## Sending
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant S as Sender (web server)
+    participant R as Relay
+
+    B->>S: POST /api/messages/direct<br/>{recipient_id, body, attachments?}
+
+    rect rgb(235, 245, 255)
+        Note over S: Encryption (HPKE)
+        S->>S: Generate random 32-byte content_key
+        S->>S: Generate random 12-byte nonce
+        S->>S: Encrypt body with<br/>ChaCha20Poly1305(content_key, nonce, body)
+        S->>S: Wrap content_key with HPKE:<br/>X25519 DH with recipient's public key<br/>→ derive shared secret via HKDF-SHA256<br/>→ encrypt content_key with ChaCha20Poly1305
+    end
+
+    rect rgb(240, 255, 240)
+        Note over S: Signing and packaging
+        S->>S: Build Header:<br/>{sender, recipient, timestamp,<br/> message_id (SHA-256 of payload),<br/> kind: Direct, ttl_seconds}
+        S->>S: Sign header with Ed25519 private key
+        S->>S: Package Envelope:<br/>{header, wrapped_key, encrypted_payload}
+    end
+
+    S->>R: POST /envelopes
+    R->>R: Validate TTL, check capacity
+    R->>R: Store in recipient's inbox<br/>(dedup by message_id)
+    R-->>S: 200 OK
+    S->>S: Store in local SQLite (outbox)
+    S-->>B: 201 Created {message_id}
+```
+
+## Receiving
+
+```mermaid
+sequenceDiagram
+    participant R as Relay
+    participant Rc as Recipient (sync loop)
+    participant DB as SQLite
+    participant UI as Browser UI
+
+    alt WebSocket push (real-time)
+        R->>Rc: Push envelope over WebSocket
+        Note over Rc: Wakes sync loop immediately
+    else Periodic poll
+        Rc->>R: GET /inbox/{peer_id}
+        R-->>Rc: [pending envelopes]
+    end
+
+    loop For each envelope
+        Rc->>Rc: Check dedup index<br/>(skip if already stored)
+        Rc->>Rc: Verify Ed25519 signature<br/>using sender's stored signing key
+        Rc->>Rc: Check TTL (discard if expired)
+
+        rect rgb(235, 245, 255)
+            Note over Rc: Decryption (HPKE)
+            Rc->>Rc: Unwrap content_key with HPKE:<br/>X25519 DH with own private key<br/>→ recover shared secret<br/>→ decrypt content_key
+            Rc->>Rc: Decrypt body with<br/>ChaCha20Poly1305(content_key, nonce, ciphertext)
+        end
+
+        Rc->>DB: INSERT message (body, sender, timestamp, …)
+        Rc->>UI: WsEvent::NewMessage<br/>{message_id, sender_id, body, timestamp}
+        UI->>UI: Display message
+    end
+```
+
+## Cryptographic Properties
+
+| Property | Mechanism |
+|---|---|
+| Confidentiality | HPKE (X25519-HKDF-SHA256 + ChaCha20Poly1305) |
+| Integrity | Ed25519 signature on header |
+| Per-message forward secrecy | Fresh random `content_key` per message |
+| Content addressing | `message_id = SHA-256(payload_bytes)` |
+| Replay prevention | Dedup index + TTL enforcement |
+| Relay sees | sender ID, recipient ID, timestamp, message size |
+| Relay cannot see | message body, content_key, or any plaintext |

--- a/docs/flows/04-store-and-forward.md
+++ b/docs/flows/04-store-and-forward.md
@@ -1,0 +1,94 @@
+# Flow: Store-and-Forward Direct Message
+
+When the intended recipient is offline and no relay is available to hold
+messages long enough, a sender can route a message through a **mutual friend**
+who stores it until the recipient reconnects.
+
+The outer envelope is encrypted for the storage peer (who unwraps and holds it),
+while the inner envelope is encrypted for the final recipient (who decrypts and
+reads it). The storage peer never sees the message content.
+
+See [architecture.md § Peer Store-and-Forward](../architecture.md#peer-store-and-forward)
+for design context.
+
+## Message Routing via Storage Peer
+
+```mermaid
+sequenceDiagram
+    participant A as Alice (sender)
+    participant R as Relay
+    participant B as Bob (storage peer, mutual friend)
+    participant C as Carol (offline recipient)
+
+    Note over C: Carol is currently offline
+
+    rect rgb(235, 245, 255)
+        Note over A: Step 1 – Build inner envelope (for Carol)
+        A->>A: Generate content_key
+        A->>A: Encrypt message with ChaCha20Poly1305(content_key)
+        A->>A: Wrap content_key with HPKE(Carol's X25519 public key)
+        A->>A: Sign header with Ed25519
+        A->>A: Inner Envelope:<br/>{recipient: Carol, kind: Direct, encrypted_payload}
+    end
+
+    rect rgb(240, 255, 240)
+        Note over A: Step 2 – Wrap inner envelope for Bob
+        A->>A: Serialize inner envelope as bytes
+        A->>A: Encrypt serialized inner envelope<br/>with HPKE(Bob's X25519 public key)
+        A->>A: Build outer Envelope:<br/>{kind: StoreForPeer,<br/> recipient_id: Bob,<br/> storage_peer_id: Bob,<br/> store_for: Carol,<br/> payload: encrypted(inner envelope)}
+        A->>A: Sign outer header with Ed25519
+    end
+
+    A->>R: POST /envelopes (outer StoreForPeer)
+    R->>R: Store in Bob's inbox
+    R-->>A: 200 OK
+
+    rect rgb(255, 245, 230)
+        Note over B: Step 3 – Bob receives and stores
+        B->>R: GET /inbox/{bob_peer_id}
+        R-->>B: [StoreForPeer envelope]
+        B->>B: Verify outer Ed25519 signature
+        B->>B: Decrypt outer payload with own X25519 key<br/>→ recover inner envelope bytes
+        B->>B: Store inner envelope in local DB<br/>(tagged store_for = Carol)
+    end
+
+    Note over C: Carol comes back online
+
+    rect rgb(255, 240, 255)
+        Note over C,B: Step 4 – Carol announces online
+        C->>R: POST /envelopes (MetaMessage::Online → Bob)
+        R->>R: Store in Bob's inbox
+        B->>R: GET /inbox/{bob_peer_id}
+        R-->>B: [Online announcement from Carol]
+        B->>B: Mark Carol as online
+    end
+
+    rect rgb(245, 235, 255)
+        Note over B,C: Step 5 – Bob forwards to Carol
+        B->>B: Look up stored envelopes for Carol
+        B->>R: POST /envelopes (inner envelope, recipient: Carol)
+        R->>R: Store in Carol's inbox
+        R-->>B: 200 OK
+    end
+
+    rect rgb(235, 255, 245)
+        Note over C: Step 6 – Carol receives and decrypts
+        C->>R: GET /inbox/{carol_peer_id}
+        R-->>C: [inner Direct envelope from Alice]
+        C->>C: Verify Alice's Ed25519 signature
+        C->>C: Unwrap content_key with HPKE(Carol's X25519 private key)
+        C->>C: Decrypt body with ChaCha20Poly1305
+        C->>C: Store message in SQLite
+    end
+
+    Note over A,C: Alice's message delivered to Carol<br/>Bob held an encrypted blob he could not read
+```
+
+## Privacy Properties
+
+| Question | Answer |
+|---|---|
+| Can Bob read Alice's message to Carol? | No — inner envelope is encrypted for Carol only |
+| Can the relay read any content? | No — both envelopes are HPKE-encrypted |
+| Does Carol learn that Bob was the storage peer? | Yes, via the `storage_peer_id` field in the outer header |
+| Does the relay know Carol is the final recipient? | Yes — `store_for` field is visible in the outer header |

--- a/docs/flows/05-public-message.md
+++ b/docs/flows/05-public-message.md
@@ -1,0 +1,76 @@
+# Flow: Public Message
+
+Public messages are timeline posts visible to peers who follow the author.
+Unlike direct messages they are **not HPKE-encrypted** (they are public by
+intent), but the header is still Ed25519-signed so recipients can verify
+authenticity.
+
+Public messages are distributed in two ways:
+1. **Direct delivery** — posted to each known friend's inbox at send time.
+2. **Mesh backfill** — peers share messages with each other on reconnect; see
+   [mesh-distribution.md](07-mesh-distribution.md).
+
+## Sending a Public Post
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant S as Sender (web server)
+    participant R as Relay
+
+    B->>S: POST /api/messages/public<br/>{body}
+
+    rect rgb(235, 245, 255)
+        Note over S: Build envelope
+        S->>S: Build Payload:<br/>{content_type: "text/plain", body}
+        S->>S: Compute message_id = SHA-256(payload)
+        S->>S: Build Header:<br/>{sender, recipient: friend,<br/> kind: Public, timestamp, ttl}
+        S->>S: Sign header with Ed25519
+    end
+
+    loop For each known friend
+        S->>R: POST /envelopes<br/>{kind: Public, recipient: Friend_N}
+        R->>R: Store in friend's inbox
+        R-->>S: 200 OK
+    end
+
+    S->>S: Store in local SQLite (own feed)
+    S-->>B: 201 Created {message_id}
+```
+
+## Receiving a Public Post
+
+```mermaid
+sequenceDiagram
+    participant R as Relay
+    participant P as Peer (sync loop)
+    participant DB as SQLite
+    participant UI as Browser UI
+
+    alt WebSocket push
+        R->>P: Push Public envelope
+    else Periodic poll
+        P->>R: GET /inbox/{peer_id}
+        R-->>P: [envelopes including Public ones]
+    end
+
+    loop For each Public envelope
+        P->>P: Check dedup index
+        P->>P: Verify Ed25519 signature<br/>using sender's stored signing key
+        P->>P: Check sender not muted/blocked
+        P->>P: Check TTL
+        P->>DB: INSERT message (kind=public, body, sender, …)
+        P->>UI: WsEvent::NewMessage
+        UI->>UI: Show in timeline feed
+    end
+```
+
+## Notes
+
+- Public message bodies are stored as plaintext in SQLite on the recipient's
+  device.
+- If the sender's signing key is not yet known (e.g. message arrived via mesh
+  from a non-friend), signature verification is deferred until the key is
+  obtained (see [peer-discovery.md](08-peer-discovery.md)).
+- Peers that the author does not know about will only receive public messages
+  via the [mesh distribution](07-mesh-distribution.md) protocol.

--- a/docs/flows/06-attachment.md
+++ b/docs/flows/06-attachment.md
@@ -1,0 +1,101 @@
+# Flow: Attachments
+
+Attachments are stored using **content addressing**: the storage key is the
+SHA-256 hash of the file bytes, so identical files are stored only once and
+hashes double as integrity proofs.
+
+For **direct and group messages**, attachment bytes are base64-encoded and
+embedded directly in the encrypted payload — the relay never sees the file
+content. For **public messages**, attachments travel as plaintext references
+that any recipient can fetch by hash.
+
+## Upload and Send (Direct Message with Attachment)
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant S as Server
+    participant DB as SQLite
+    participant R as Relay
+    participant Rc as Recipient
+
+    rect rgb(235, 245, 255)
+        Note over B,S: Step 1 – Upload attachment
+        B->>S: POST /api/attachments<br/>multipart/form-data (file bytes)
+        S->>S: Compute content_hash = SHA-256(file_bytes)
+        S->>DB: INSERT INTO attachments<br/>(content_hash, content_type, size, data)
+        S-->>B: 201 Created<br/>{content_hash, content_type, size_bytes}
+    end
+
+    rect rgb(240, 255, 240)
+        Note over B,S: Step 2 – Send message referencing attachment
+        B->>S: POST /api/messages/direct<br/>{recipient_id, body,<br/> attachments: [{hash, content_type, size}]}
+        S->>DB: SELECT data FROM attachments WHERE content_hash = ?
+        S->>S: Build payload:<br/>{body, attachments: [{hash, data_base64, …}]}
+        S->>S: Encrypt entire payload with HPKE<br/>(attachment bytes included in ciphertext)
+        S->>S: Sign header with Ed25519
+        S->>R: POST /envelopes
+        R->>R: Store encrypted envelope<br/>(relay cannot see file content)
+        R-->>S: 200 OK
+        S-->>B: 201 Created
+    end
+
+    rect rgb(255, 245, 230)
+        Note over R,Rc: Step 3 – Recipient receives and stores
+        Rc->>R: GET /inbox/{peer_id}
+        R-->>Rc: [encrypted Direct envelope]
+        Rc->>Rc: Verify signature
+        Rc->>Rc: Decrypt payload (HPKE + ChaCha20Poly1305)
+        Rc->>Rc: Extract attachment bytes from decrypted payload
+        Rc->>Rc: Verify: SHA-256(bytes) == content_hash
+        Rc->>DB: INSERT INTO attachments (content_hash, data, …)
+        Rc->>DB: INSERT INTO message_attachments (message_id, content_hash)
+        Rc->>DB: INSERT INTO messages
+    end
+
+    rect rgb(255, 240, 255)
+        Note over B,Rc: Step 4 – Retrieve attachment later
+        B->>S: GET /api/attachments/{content_hash}
+        S->>DB: SELECT data FROM attachments WHERE content_hash = ?
+        S-->>B: file bytes (with correct Content-Type)
+    end
+```
+
+## Public Message with Attachment
+
+For public messages, attachments are referenced by hash but **not embedded** in
+the envelope. Recipients fetch the attachment separately from the original
+sender or a peer who has it.
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant S as Author's Server
+    participant R as Relay
+    participant P as Peer
+
+    B->>S: POST /api/attachments (upload)
+    S-->>B: {content_hash}
+
+    B->>S: POST /api/messages/public<br/>{body, attachments: [{hash, …}]}
+    S->>S: Build Public envelope:<br/>payload references hash only (no embedded bytes)
+    S->>R: POST /envelopes
+    R-->>P: envelope delivered
+
+    P->>P: Receive public message<br/>with attachment reference {hash}
+    Note over P: Attachment bytes not in envelope
+    P->>S: GET /api/attachments/{content_hash}
+    S-->>P: file bytes
+    P->>P: Verify SHA-256(bytes) == hash
+    P->>P: Store attachment locally
+```
+
+## Content Addressing Properties
+
+| Property | Detail |
+|---|---|
+| Deduplication | Same file uploaded multiple times stores only once |
+| Integrity | `SHA-256(bytes) == content_hash` verified on receive |
+| Privacy (Direct) | Attachment bytes are inside the HPKE ciphertext |
+| Privacy (Public) | Attachment bytes are fetched in plaintext from sender |
+| Relay visibility | For Direct messages: none (hash is in encrypted header) |

--- a/docs/flows/07-mesh-distribution.md
+++ b/docs/flows/07-mesh-distribution.md
@@ -1,0 +1,98 @@
+# Flow: Mesh Distribution of Past Public Messages
+
+Peers share public messages they have seen with each other using a
+four-message gossip protocol. This allows a peer to catch up on content it
+missed while offline and to receive posts from peers it is not directly
+connected to.
+
+The protocol is rate-limited per peer: queries are only sent at most once per
+`MESH_QUERY_INTERVAL_SECS` interval.
+
+## Four-Way Gossip Handshake
+
+```mermaid
+sequenceDiagram
+    participant A as Peer A
+    participant R as Relay
+    participant B as Peer B
+
+    Note over A: A reconnects / sync loop fires<br/>Wants public messages since timestamp T
+
+    rect rgb(235, 245, 255)
+        Note over A,R: Step 1 – A asks B what it has
+        A->>A: Build MetaMessage::MessageRequest<br/>{peer_id: A, since_timestamp: T}
+        A->>A: Sign envelope header
+        A->>R: POST /envelopes → B
+        R->>R: Store in B's inbox
+    end
+
+    rect rgb(240, 255, 240)
+        Note over B,R: Step 2 – B advertises available messages
+        B->>R: GET /inbox/{B}
+        R-->>B: [MessageRequest from A]
+        B->>B: Query local DB for public messages since T
+        B->>B: Build MetaMessage::MeshAvailable<br/>{peer_id: B,<br/> message_ids: [id1, id2, …],<br/> since_timestamp: T}
+        B->>R: POST /envelopes → A
+    end
+
+    rect rgb(255, 245, 230)
+        Note over A,R: Step 3 – A requests messages it is missing
+        A->>R: GET /inbox/{A}
+        R-->>A: [MeshAvailable from B]
+        A->>A: Check each message_id against local dedup index
+        A->>A: Build MetaMessage::MeshRequest<br/>{peer_id: A,<br/> message_ids: [id1, id3, …]}  ← only missing ones
+        A->>R: POST /envelopes → B
+    end
+
+    rect rgb(255, 240, 255)
+        Note over B,R: Step 4 – B delivers the requested envelopes
+        B->>R: GET /inbox/{B}
+        R-->>B: [MeshRequest from A]
+        B->>B: Look up requested envelopes in local DB
+        B->>B: Build MetaMessage::MeshDelivery<br/>{peer_id: B,<br/> envelopes: [env1, env3, …],<br/> sender_keys: {sender_id: signing_key_hex, …}}
+        Note over B: sender_keys lets A verify signatures<br/>from peers A has never met
+        B->>R: POST /envelopes → A
+    end
+
+    rect rgb(235, 255, 245)
+        Note over A: Step 5 – A processes new messages
+        A->>R: GET /inbox/{A}
+        R-->>A: [MeshDelivery from B]
+        loop For each delivered envelope
+            A->>A: Check dedup index (skip duplicates)
+            A->>A: Verify sender's Ed25519 signature<br/>using sender_keys from delivery
+            A->>A: Store signing key for future verification
+            A->>A: Store message in SQLite
+            A->>A: Broadcast WsEvent::NewMessage to browser
+        end
+    end
+```
+
+## Backfilling Signatures
+
+When a message arrives via mesh from a peer A has never added as a friend,
+A has no stored signing key for that sender. The `sender_keys` map in
+`MeshDelivery` solves this:
+
+```mermaid
+sequenceDiagram
+    participant A as Peer A
+    participant B as Peer B (delivery peer)
+
+    Note over A: Receives MeshDelivery containing<br/>message from unknown Peer C
+
+    A->>A: Check: SHA-256(key_bytes) == sender_id?
+    Note over A: Peer ID is derived from public key,<br/>so the key is self-authenticating
+    A->>A: Store C's signing key locally
+    A->>A: Verify C's Ed25519 signature
+    A->>A: Backfill signatures for any<br/>previously unverified messages from C
+```
+
+## Scope and Rate Limiting
+
+- Mesh queries use `DEFAULT_MESH_WINDOW_SECS` (e.g. 24 h) as the lookback window.
+- Each peer is queried at most once per `MESH_QUERY_INTERVAL_SECS`.
+- Only **public** messages are shared via mesh; direct and group messages are
+  not included in `MeshDelivery`.
+- A peer that has no new messages simply sends `MeshAvailable` with an empty
+  list, and A sends no `MeshRequest`.

--- a/docs/flows/08-peer-discovery.md
+++ b/docs/flows/08-peer-discovery.md
@@ -1,0 +1,126 @@
+# Flow: Peer Discovery and Public Key Fetching
+
+Tenet uses a **Trust on First Use (TOFU)** model. Peers learn each other's
+public keys through explicit handshakes or via the mesh delivery protocol.
+There is no global key directory — key distribution is decentralised.
+
+## How Peers Learn Each Other's Keys
+
+There are three paths to obtaining a peer's public keys:
+
+| Path | When used |
+|---|---|
+| Friend request handshake | Adding a new friend directly |
+| Mesh delivery (`sender_keys`) | Receiving posts from peers of peers |
+| Profile request / response | Refreshing or fetching profile data |
+
+## Path 1: Friend Request (Direct Key Exchange)
+
+The [friend request flow](01-add-friend.md) is the primary key exchange
+mechanism. Keys are embedded in the plaintext `FriendRequest` and `FriendAccept`
+meta messages.
+
+```mermaid
+sequenceDiagram
+    participant A as Alice
+    participant R as Relay
+    participant B as Bob
+
+    Note over A: Knows only Bob's Peer ID<br/>(shared out-of-band, e.g. QR code)
+
+    A->>R: POST /envelopes → Bob<br/>FriendRequest {signing_key, encryption_key}
+    R-->>B: delivered
+
+    B->>R: POST /envelopes → Alice<br/>FriendAccept {signing_key, encryption_key}
+    R-->>A: delivered
+
+    Note over A,B: Both peers now have each other's<br/>Ed25519 signing key and X25519 encryption key
+    Note over A,B: Peer ID binding:<br/>SHA-256(signing_public_key) == peer_id<br/>→ key cannot be forged for an existing ID
+```
+
+## Path 2: Mesh Delivery (Keys from Unknown Peers)
+
+When a peer receives messages via [mesh distribution](07-mesh-distribution.md)
+from someone it has never met, the delivering peer includes a `sender_keys` map
+so the receiver can verify signatures.
+
+```mermaid
+sequenceDiagram
+    participant A as Alice
+    participant B as Bob (mutual friend)
+    participant C as Carol (unknown to Alice)
+
+    Note over C,B: Carol posts a public message<br/>Bob has seen it
+
+    B->>A: MeshDelivery<br/>{envelopes: [Carol's post],<br/> sender_keys: {"carol_id": carol_signing_key_hex}}
+
+    rect rgb(235, 245, 255)
+        Note over A: Verify key is self-authenticating
+        A->>A: Compute SHA-256(carol_signing_key_bytes)
+        A->>A: Compare with carol_id in envelope header
+        Note over A: Match → key cannot be forged
+    end
+
+    A->>A: Verify Carol's Ed25519 signature
+    A->>A: Store Carol's signing key locally
+    A->>A: Backfill: verify any earlier unverified<br/>messages from Carol
+    Note over A: Alice can now verify Carol's future messages<br/>even without being friends
+```
+
+## Path 3: Profile Request
+
+```mermaid
+sequenceDiagram
+    participant A as Alice
+    participant R as Relay
+    participant B as Bob
+
+    Note over A: Bob's profile is missing or stale<br/>(checked hourly for missing, daily for stale)
+
+    A->>A: Build MetaMessage::ProfileRequest<br/>{peer_id: Alice, for_peer_id: Bob}
+    A->>R: POST /envelopes → Bob
+    R-->>B: delivered
+
+    B->>B: Receive ProfileRequest
+    B->>B: Build profile payload:<br/>{"type":"tenet.profile", "display_name":…, "bio":…}
+    B->>B: Encrypt for Alice (HPKE Direct message)
+    B->>R: POST /envelopes → Alice
+    R-->>A: delivered
+
+    A->>A: Decrypt profile message
+    A->>A: Upsert profiles table
+    A->>A: Broadcast WsEvent::ProfileUpdated to browser
+```
+
+## Signature Verification on Receive
+
+Every received envelope is checked against the sender's known signing key.
+
+```mermaid
+sequenceDiagram
+    participant P as Peer (sync loop)
+    participant DB as SQLite
+
+    P->>P: Receive envelope from sender X
+
+    alt Sender X is a known peer
+        P->>DB: SELECT signing_public_key FROM peers WHERE peer_id = X
+        DB-->>P: key_hex
+        P->>P: Verify Ed25519 signature ✓
+    else Sender X is unknown (e.g. public message via mesh)
+        P->>P: Check sender_keys from MeshDelivery
+        P->>P: Verify SHA-256(key) == sender_id
+        P->>P: Verify Ed25519 signature ✓
+        P->>DB: Cache signing key for future verification
+    else Key not available
+        P->>P: Store message with signature_verified = false
+        Note over P: Key may arrive later via mesh or profile request
+    end
+```
+
+## Key Binding Guarantee
+
+The Peer ID is `SHA-256(signing_public_key)`. Because SHA-256 is
+preimage-resistant, an attacker cannot manufacture a signing key that hashes to
+an existing Peer ID. Possessing a valid signature proves ownership of the
+corresponding private key.

--- a/docs/flows/09-profile-updates.md
+++ b/docs/flows/09-profile-updates.md
@@ -1,0 +1,117 @@
+# Flow: Profile Updates
+
+Each peer maintains a profile (display name, bio, avatar hash). Profiles are
+distributed to friends either **proactively** when a user updates their own
+profile, or **reactively** in response to a `ProfileRequest` from another peer.
+
+Profile data is sent as an encrypted Direct message so only the intended
+recipient can read it.
+
+## Push: Updating Your Own Profile
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant S as Server
+    participant DB as SQLite
+    participant R as Relay
+
+    B->>S: PUT /api/profile<br/>{display_name, bio, avatar_hash?}
+    S->>DB: UPSERT profiles (user_id = own_peer_id, …)
+    S-->>B: 200 OK {profile}
+
+    rect rgb(235, 245, 255)
+        Note over S: Broadcast updated profile to all friends
+        S->>DB: SELECT peer_id FROM peers WHERE is_friend = true
+        loop For each friend
+            S->>S: Build profile payload:<br/>{"type":"tenet.profile",<br/> "user_id": own_id,<br/> "display_name": "…",<br/> "bio": "…",<br/> "avatar_hash": "…"}
+            S->>S: Encrypt for friend (HPKE Direct message)
+            S->>S: Sign header with Ed25519
+            S->>R: POST /envelopes → Friend
+            R->>R: Store in friend's inbox
+        end
+    end
+```
+
+## Receive: Incoming Profile Update
+
+```mermaid
+sequenceDiagram
+    participant R as Relay
+    participant P as Peer (sync loop)
+    participant DB as SQLite
+    participant UI as Browser UI
+
+    P->>R: GET /inbox/{peer_id}
+    R-->>P: [Direct envelope containing profile]
+
+    P->>P: Verify Ed25519 signature
+    P->>P: Decrypt HPKE payload
+    P->>P: Parse JSON body<br/>{type: "tenet.profile", display_name, bio, …}
+    P->>DB: UPSERT profiles (user_id = sender_id, …)
+    P->>DB: UPDATE peers SET last_profile_responded_at = now()
+    P->>UI: WsEvent::ProfileUpdated<br/>{peer_id, display_name, bio, avatar_hash}
+    UI->>UI: Refresh peer display name / avatar
+```
+
+## Pull: Requesting a Peer's Profile
+
+Profiles are also requested automatically by the background sync loop for peers
+whose profile is missing or stale (hourly for missing, daily for stale).
+
+```mermaid
+sequenceDiagram
+    participant A as Alice (sync loop)
+    participant R as Relay
+    participant B as Bob
+
+    Note over A: Bob has no profile data yet<br/>OR last_profile_responded_at > 1 hour ago
+
+    rect rgb(235, 245, 255)
+        Note over A,R: Alice sends ProfileRequest
+        A->>A: Build MetaMessage::ProfileRequest<br/>{peer_id: Alice, for_peer_id: Bob}
+        A->>A: Sign envelope header
+        A->>R: POST /envelopes → Bob
+        R->>R: Store in Bob's inbox
+        A->>A: Record last_profile_requested_at = now()
+    end
+
+    rect rgb(240, 255, 240)
+        Note over B,R: Bob responds with his profile
+        B->>R: GET /inbox/{bob_peer_id}
+        R-->>B: [ProfileRequest from Alice]
+        B->>B: Build own profile payload
+        B->>B: Encrypt for Alice (HPKE Direct message)
+        B->>R: POST /envelopes → Alice
+    end
+
+    rect rgb(255, 245, 230)
+        Note over A: Alice receives and stores Bob's profile
+        A->>R: GET /inbox/{alice_peer_id}
+        R-->>A: [profile Direct message from Bob]
+        A->>A: Decrypt and parse profile
+        A->>A: UPSERT profiles table
+        A->>A: UPDATE peers.last_profile_responded_at
+        A->>A: WsEvent::ProfileUpdated → browser
+    end
+```
+
+## Manual Profile Request
+
+A user can also manually request a peer's profile from the web UI:
+
+```
+POST /api/peers/{peer_id}/request-profile
+```
+
+This sends an immediate `ProfileRequest` MetaMessage regardless of the
+rate-limit timers.
+
+## Profile Data Fields
+
+| Field | Description |
+|---|---|
+| `display_name` | Human-readable name shown in the UI |
+| `bio` | Short description / status text |
+| `avatar_hash` | SHA-256 content hash of an avatar image attachment |
+| `user_id` | Peer ID of the profile owner (for attribution) |

--- a/docs/flows/10-group-create-invite.md
+++ b/docs/flows/10-group-create-invite.md
@@ -1,0 +1,120 @@
+# Flow: Group Creation and Invite
+
+Groups share a 32-byte symmetric key. The creator generates the key and
+distributes it to each member **after** they explicitly accept an invitation.
+This consent model ensures no peer receives a group key without agreeing to join.
+
+See [groups.md](../groups.md) for REST API reference and schema details.
+
+## Creating a Group and Inviting Members
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant Cr as Creator (server)
+    participant R as Relay
+    participant M1 as Member 1
+    participant M2 as Member 2
+
+    B->>Cr: POST /api/groups<br/>{group_id, member_ids: [M1, M2], message?}
+
+    rect rgb(235, 245, 255)
+        Note over Cr: Setup
+        Cr->>Cr: Generate random 32-byte group_key
+        Cr->>Cr: INSERT INTO groups (group_id, group_key, creator_id)
+        Cr->>Cr: INSERT INTO group_members (group_id, creator_id) ← creator joins immediately
+    end
+
+    rect rgb(240, 255, 240)
+        Note over Cr,R: Send invitations (no key yet)
+        loop For each invited member
+            Cr->>Cr: Build MetaMessage::GroupInvite<br/>{peer_id: creator, group_id, message?}
+            Cr->>Cr: Sign envelope header
+            Cr->>R: POST /envelopes → Member
+            R->>R: Store in member's inbox
+            Cr->>Cr: INSERT INTO group_invites<br/>(status=pending, direction=outgoing)
+        end
+    end
+
+    Cr-->>B: 201 Created {group_id}
+
+    rect rgb(255, 245, 230)
+        Note over M1,R: Member 1 receives invite
+        M1->>R: GET /inbox/{M1_peer_id}
+        R-->>M1: [GroupInvite envelope]
+        M1->>M1: Verify creator's Ed25519 signature
+        M1->>M1: INSERT INTO group_invites<br/>(status=pending, direction=incoming)
+        M1->>M1: WsEvent::GroupInviteReceived → browser
+        Note over M1: UI shows Accept / Ignore
+    end
+
+    rect rgb(255, 240, 255)
+        Note over M1,R: Member 1 accepts
+        M1->>Cr: POST /api/group-invites/{id}/accept
+        M1->>M1: UPDATE group_invites SET status=accepted
+        M1->>M1: Build MetaMessage::GroupInviteAccept<br/>{peer_id: M1, group_id}
+        M1->>R: POST /envelopes → Creator
+        R->>R: Store in creator's inbox
+    end
+
+    rect rgb(245, 235, 255)
+        Note over Cr,R: Creator distributes group key to M1
+        Cr->>R: GET /inbox/{creator_peer_id}
+        R-->>Cr: [GroupInviteAccept from M1]
+        Cr->>Cr: UPDATE group_invites SET status=accepted (outgoing)
+        Cr->>Cr: INSERT INTO group_members (group_id, M1)
+        Cr->>Cr: WsEvent::GroupMemberJoined → browser
+        Cr->>Cr: Build group_key_distribution payload:<br/>{"type":"group_key_distribution",<br/> "group_id": "…",<br/> "group_key": "<hex>",<br/> "key_version": 1,<br/> "creator_id": "…"}
+        Cr->>Cr: Encrypt for M1 (HPKE Direct message)
+        Cr->>R: POST /envelopes → M1
+    end
+
+    rect rgb(235, 255, 245)
+        Note over M1: M1 receives group key
+        M1->>R: GET /inbox/{M1_peer_id}
+        R-->>M1: [group_key_distribution from Creator]
+        M1->>M1: Decrypt HPKE payload
+        M1->>M1: Consent check:<br/>verify accepted invite exists from this creator
+        M1->>M1: INSERT INTO groups (group_id, group_key, key_version)
+        M1->>M1: INSERT INTO group_members (group_id, M1)
+        Note over M1: Can now decrypt FriendGroup messages
+    end
+
+    Note over M2: Same flow runs independently for M2
+```
+
+## Adding a Member Later
+
+```mermaid
+sequenceDiagram
+    participant Cr as Creator
+    participant R as Relay
+    participant New as New Member
+
+    Cr->>R: POST /api/groups/{id}/members<br/>{peer_id: New}
+    Note over Cr,New: Same GroupInvite → GroupInviteAccept<br/>→ group_key_distribution flow as above
+```
+
+## Consent Model
+
+```mermaid
+sequenceDiagram
+    participant Cr as Creator
+    participant R as Relay
+    participant M as Invitee
+
+    Cr->>R: GroupInvite → M
+    R-->>M: delivered
+    Note over M: Does NOT have the group key yet
+    Note over M: Cannot decrypt any FriendGroup messages yet
+
+    alt M ignores
+        Note over M: status = "ignored"<br/>No response sent<br/>Creator's invite stays "pending"
+    else M accepts
+        M->>R: GroupInviteAccept → Creator
+        R-->>Cr: delivered
+        Cr->>R: group_key_distribution → M
+        R-->>M: delivered
+        Note over M: NOW has the group key<br/>Can decrypt FriendGroup messages
+    end
+```

--- a/docs/flows/11-group-message.md
+++ b/docs/flows/11-group-message.md
@@ -1,0 +1,117 @@
+# Flow: Group Message
+
+Once a member holds the group's symmetric key they can send and receive group
+messages. Unlike direct messages which use HPKE per-recipient wrapping, group
+messages use **a single ChaCha20Poly1305 symmetric key** shared by all members.
+Every member uses the same key to decrypt.
+
+See [group-create-invite.md](10-group-create-invite.md) for how the key is
+established, and [groups.md](../groups.md) for the full API reference.
+
+## Sending a Group Message
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant S as Sender (server)
+    participant DB as SQLite
+    participant R as Relay
+
+    B->>S: POST /api/messages/group<br/>{group_id, body}
+
+    rect rgb(235, 245, 255)
+        Note over S: Encrypt with group key
+        S->>DB: SELECT group_key FROM groups WHERE group_id = ?
+        DB-->>S: group_key (32 bytes)
+        S->>S: Generate random 12-byte nonce
+        S->>S: Encrypt body with<br/>ChaCha20Poly1305(group_key, nonce, body)
+        S->>S: Compute message_id = SHA-256(payload)
+    end
+
+    rect rgb(240, 255, 240)
+        Note over S: Build and sign envelope
+        S->>S: Build Header:<br/>{sender, recipient: member_N,<br/> kind: FriendGroup,<br/> group_id, timestamp, ttl}
+        S->>S: Sign header with Ed25519
+    end
+
+    rect rgb(255, 245, 230)
+        Note over S,R: Deliver to each group member individually
+        S->>DB: SELECT peer_id FROM group_members WHERE group_id = ?<br/>AND peer_id != own_id
+        loop For each member
+            S->>R: POST /envelopes<br/>{kind: FriendGroup, recipient: member_N}
+            R->>R: Store in member's inbox
+        end
+    end
+
+    S->>DB: INSERT message (own copy, kind=friend_group)
+    S-->>B: 201 Created {message_id}
+```
+
+## Receiving a Group Message
+
+```mermaid
+sequenceDiagram
+    participant R as Relay
+    participant M as Member (sync loop)
+    participant DB as SQLite
+    participant UI as Browser UI
+
+    alt WebSocket push
+        R->>M: Push FriendGroup envelope
+    else Periodic poll
+        M->>R: GET /inbox/{peer_id}
+        R-->>M: [envelopes including FriendGroup ones]
+    end
+
+    loop For each FriendGroup envelope
+        M->>M: Check dedup index
+        M->>M: Verify Ed25519 signature<br/>using sender's stored signing key
+        M->>M: Check TTL
+
+        rect rgb(235, 245, 255)
+            Note over M: Decrypt with group key
+            M->>DB: SELECT group_key FROM groups WHERE group_id = ?
+            DB-->>M: group_key
+            M->>M: Decrypt with ChaCha20Poly1305(group_key, nonce, ciphertext)
+        end
+
+        M->>DB: INSERT message (body, sender, group_id, kind=friend_group)
+        M->>UI: WsEvent::NewMessage<br/>{message_id, sender_id, kind: "friend_group", body}
+        UI->>UI: Show in group conversation
+    end
+```
+
+## Comparison: Group vs Direct Encryption
+
+```mermaid
+sequenceDiagram
+    participant S as Sender
+    participant R as Relay
+    participant A as Member A
+    participant B as Member B
+
+    Note over S,B: Group message (one key, multiple recipients)
+    S->>S: Encrypt with group_key (shared)
+    S->>R: POST /envelopes → A (FriendGroup)
+    S->>R: POST /envelopes → B (FriendGroup)
+    A->>A: Decrypt with group_key
+    B->>B: Decrypt with group_key
+
+    Note over S,B: Direct message (different key wrap per recipient)
+    S->>S: Generate content_key
+    S->>S: HPKE-wrap for A using A's X25519 key
+    S->>R: POST /envelopes → A (Direct)
+    S->>S: HPKE-wrap for B using B's X25519 key
+    S->>R: POST /envelopes → B (Direct)
+    A->>A: HPKE-unwrap with A's private key
+    B->>B: HPKE-unwrap with B's private key
+```
+
+## Known Limitations
+
+- **No key rotation on member removal**: removing a member from the group does
+  not generate a new group key. The removed member retains their copy of the
+  old key and can decrypt past (and future) messages if they store them.
+- **One group key per group**: all messages use the same key regardless of
+  when a member joined. A member who joins later and receives the current key
+  could theoretically decrypt past messages if they obtain old ciphertext.

--- a/docs/flows/12-reactions-replies.md
+++ b/docs/flows/12-reactions-replies.md
@@ -1,0 +1,99 @@
+# Flow: Reactions and Replies
+
+Reactions (upvote / downvote) and threaded replies extend public and group
+messages. Both are delivered via the relay like any other envelope and reference
+the original message by its `message_id`.
+
+## Reactions
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant S as Server
+    participant DB as SQLite
+    participant R as Relay
+    participant Au as Author (original poster)
+
+    B->>S: POST /api/messages/{id}/react<br/>{reaction: "upvote"}
+
+    S->>DB: SELECT message FROM messages WHERE id = ?
+    DB-->>S: original message (sender_id, kind, …)
+
+    rect rgb(235, 245, 255)
+        Note over S: Build reaction payload (Meta message)
+        S->>S: Build reaction JSON:<br/>{"type":"reaction",<br/> "message_id": "{id}",<br/> "reaction": "upvote",<br/> "peer_id": own_id}
+        S->>S: Sign envelope header
+    end
+
+    S->>R: POST /envelopes → Author (Meta kind)
+    R->>R: Store in Author's inbox
+    S->>DB: UPSERT reactions (message_id, peer_id, reaction)
+    S-->>B: 200 OK
+
+    rect rgb(240, 255, 240)
+        Note over Au: Author receives reaction
+        Au->>R: GET /inbox/{author_peer_id}
+        R-->>Au: [reaction Meta envelope]
+        Au->>Au: Parse reaction payload
+        Au->>DB: UPSERT reactions table
+        Au->>Au: Create notification
+        Au->>Au: WsEvent::Notification → browser
+    end
+```
+
+## Threaded Replies
+
+Replies reference the parent message via the `reply_to` field in the envelope
+header. They are otherwise sent and received like regular public or group
+messages.
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant S as Server
+    participant R as Relay
+    participant P as Peers
+
+    B->>S: POST /api/messages/{parent_id}/reply<br/>{body}
+
+    S->>S: Build Public (or FriendGroup) envelope
+    Note over S: header.reply_to = parent_id
+
+    rect rgb(235, 245, 255)
+        Note over S: Sign and deliver
+        S->>S: Sign header with Ed25519
+        loop For each known friend (or group member)
+            S->>R: POST /envelopes<br/>{kind: Public, reply_to: parent_id}
+        end
+    end
+
+    S->>S: Store locally (reply_to column set)
+    S-->>B: 201 Created {message_id}
+
+    rect rgb(240, 255, 240)
+        Note over P: Recipients receive reply
+        P->>R: GET /inbox/{peer_id}
+        R-->>P: [reply envelope with reply_to]
+        P->>P: Verify signature
+        P->>P: Store message with reply_to set
+        P->>P: WsEvent::NewMessage → browser
+        Note over P: UI threads reply under parent message
+    end
+```
+
+## Removing a Reaction
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant S as Server
+    participant DB as SQLite
+    participant R as Relay
+
+    B->>S: DELETE /api/messages/{id}/react
+
+    S->>DB: DELETE FROM reactions WHERE message_id=? AND peer_id=own_id
+    S->>S: Build reaction removal payload:<br/>{"type":"reaction_remove", "message_id": "…"}
+    S->>R: POST /envelopes → Author (Meta kind)
+    S-->>B: 200 OK
+```

--- a/docs/flows/13-relay-websocket.md
+++ b/docs/flows/13-relay-websocket.md
@@ -1,0 +1,123 @@
+# Flow: Relay WebSocket Push
+
+The relay exposes a WebSocket endpoint (`/ws/{recipient_id}`) that pushes
+incoming envelopes to connected clients in real time. This eliminates polling
+latency when a peer is actively online.
+
+The web client opens **two** WebSocket connections:
+1. **Relay WS** — to the relay server (`/ws/{peer_id}`), for real-time envelope push.
+2. **Local WS** — to the web server (`/api/ws`), for UI updates (new messages, peer status, etc.).
+
+## Connection and Push Flow
+
+```mermaid
+sequenceDiagram
+    participant UI as Browser UI
+    participant WS as Web Server (local WS)
+    participant Sync as Sync Loop (background task)
+    participant Relay as Relay Server
+    participant Sender as Sending Peer
+
+    rect rgb(235, 245, 255)
+        Note over UI,WS: Startup – open local WebSocket
+        UI->>WS: GET /api/ws (upgrade)
+        WS-->>UI: 101 Switching Protocols
+    end
+
+    rect rgb(240, 255, 240)
+        Note over Sync,Relay: Startup – open relay WebSocket
+        Sync->>Relay: GET /ws/{peer_id}?token=<auth>
+        Relay-->>Sync: 101 Switching Protocols
+        Sync->>Relay: {"type":"hello","version":"…"}
+    end
+
+    rect rgb(255, 245, 230)
+        Note over Sender,Relay: Sender posts a message
+        Sender->>Relay: POST /envelopes → this peer
+        Relay->>Relay: Store envelope in inbox
+        Relay->>Sync: Push envelope over WebSocket
+    end
+
+    rect rgb(255, 240, 255)
+        Note over Sync,WS: Sync loop wakes and processes
+        Sync->>Sync: Notify wakes relay_sync_loop immediately<br/>(no wait for polling interval)
+        Sync->>Relay: GET /inbox/{peer_id}
+        Relay-->>Sync: [new envelope(s)]
+        Sync->>Sync: Verify signature
+        Sync->>Sync: Decrypt payload
+        Sync->>Sync: Store in SQLite
+        Sync->>WS: WsEvent::NewMessage (broadcast channel)
+        WS->>UI: {"type":"new_message", "message_id":"…", …}
+        UI->>UI: Display message immediately
+    end
+```
+
+## Auth Token for Relay WebSocket
+
+The relay WebSocket endpoint requires a short-lived authentication token to
+prevent unauthorized inbox access.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant R as Relay
+
+    Note over C: Generate auth token
+    C->>C: token = peer_id + "." + unix_ts + "." + Ed25519_sig<br/>sig covers: "tenet-relay-auth\n{peer_id}\n{timestamp}"
+
+    C->>R: GET /ws/{peer_id}?token={token}
+    R->>R: Parse token: extract peer_id, timestamp, sig
+    R->>R: Verify timestamp within ±60 seconds
+    R->>R: Verify Ed25519 signature
+    alt Valid
+        R-->>C: 101 Switching Protocols
+    else Invalid or expired
+        R-->>C: 401 Unauthorized
+    end
+```
+
+## Reconnect with Backoff
+
+If the relay WebSocket disconnects, the client reconnects with exponential
+backoff (2 s, 4 s, 8 s … up to 60 s). Polling continues as a fallback during
+the disconnected interval.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant R as Relay
+
+    C->>R: connect
+    R-->>C: disconnect (network error)
+
+    loop Reconnect attempts
+        Note over C: Wait 2s → 4s → 8s … (max 60s)
+        C->>R: reconnect attempt
+        alt Success
+            R-->>C: 101 Switching Protocols
+            Note over C: backoff resets to 2s
+        else Failure
+            Note over C: double backoff, retry
+        end
+    end
+
+    Note over C: Periodic polling continues<br/>as fallback while WS is down
+```
+
+## WebSocket Events (Local UI Channel)
+
+The web server broadcasts the following events to the browser over `/api/ws`:
+
+| Event | Trigger |
+|---|---|
+| `new_message` | New message stored (any kind) |
+| `message_read` | Message marked as read |
+| `peer_online` | `MetaMessage::Online` received |
+| `peer_offline` | Peer marked offline (timeout) |
+| `friend_request_received` | Incoming friend request |
+| `friend_request_accepted` | Outgoing request accepted |
+| `group_invite_received` | Incoming group invite |
+| `group_member_joined` | Member accepted group invite |
+| `profile_updated` | Profile data received for a peer |
+| `relay_status` | Relay connected / disconnected |
+| `notification` | Any notifiable event |

--- a/docs/flows/README.md
+++ b/docs/flows/README.md
@@ -1,0 +1,57 @@
+# Protocol Flow Diagrams
+
+Mermaid sequence diagrams for the major Tenet protocol flows. Each diagram
+shows the messages exchanged between peers, the relay, and client components.
+
+## Index
+
+| # | Flow | Description |
+|---|---|---|
+| 01 | [Add Friend](01-add-friend.md) | Mutual key exchange handshake; establishes encrypted channel |
+| 02 | [Peer Reconnect](02-peer-reconnect.md) | Online announcement, inbox polling, mesh queries on startup |
+| 03 | [Direct Message](03-direct-message.md) | HPKE encryption, signing, relay delivery, and decryption |
+| 04 | [Store-and-Forward](04-store-and-forward.md) | Routing a message through a mutual friend for an offline recipient |
+| 05 | [Public Message](05-public-message.md) | Timeline post delivery to known friends |
+| 06 | [Attachment](06-attachment.md) | Content-addressed file upload, embedding in encrypted payloads, and download |
+| 07 | [Mesh Distribution](07-mesh-distribution.md) | Four-way gossip protocol for sharing past public messages |
+| 08 | [Peer Discovery](08-peer-discovery.md) | How signing and encryption keys are obtained and verified |
+| 09 | [Profile Updates](09-profile-updates.md) | Push profile to friends; pull profile on request |
+| 10 | [Group Create & Invite](10-group-create-invite.md) | Group creation, consent-based invite, and key distribution |
+| 11 | [Group Message](11-group-message.md) | Sending and receiving messages with the shared group key |
+| 12 | [Reactions & Replies](12-reactions-replies.md) | Upvote/downvote reactions and threaded replies |
+| 13 | [Relay WebSocket Push](13-relay-websocket.md) | Real-time envelope delivery and local UI event broadcasting |
+
+## Reading the Diagrams
+
+- **Participants** represent distinct roles: `Peer`, `Relay`, `Browser UI`,
+  `SQLite`, etc.
+- **Solid arrows** (`->>`) are messages sent; **dashed arrows** (`-->>`) are
+  responses.
+- **Coloured `rect` blocks** group related steps into phases.
+- **Notes** explain preconditions, decisions, or side effects.
+
+## Core Concepts
+
+### Message Kinds
+
+| Kind | Purpose | Encrypted? |
+|---|---|---|
+| `Public` | Timeline posts | No (signed only) |
+| `Direct` | 1-to-1 messages | HPKE per-recipient |
+| `FriendGroup` | Group messages | Symmetric group key |
+| `Meta` | Protocol messages (friend requests, online, profiles, mesh) | Plaintext or per-recipient |
+| `StoreForPeer` | Outer wrapper for store-and-forward | HPKE for storage peer |
+
+### Relay Role
+
+The relay is **untrusted by design**. It stores opaque encrypted blobs and
+routes them by `recipient_id`. It can observe sender ID, recipient ID,
+timestamps, and message sizes — but never plaintext content.
+
+### Key Types
+
+| Key | Algorithm | Derived ID |
+|---|---|---|
+| Signing key | Ed25519 | `SHA-256(signing_pub_key)` = Peer ID |
+| Encryption key | X25519 (for HPKE) | — |
+| Group key | 32-byte random symmetric | — |

--- a/docs/friend_requests.md
+++ b/docs/friend_requests.md
@@ -156,6 +156,9 @@ At this point, both peers have each other's keys and can exchange fully encrypte
 
 ## Sequence Diagram
 
+See [flows/01-add-friend.md](flows/01-add-friend.md) for the full Mermaid sequence diagram,
+including the block/ignore variants and security notes.
+
 ```
 Initiator                     Relay                      Recipient
     |                           |                            |

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -39,6 +39,10 @@ the `group_invites` table with `status = "pending"` and `direction = "outgoing"`
 
 ## Invite Flow
 
+See [flows/10-group-create-invite.md](flows/10-group-create-invite.md) for the full Mermaid
+sequence diagram and [flows/11-group-message.md](flows/11-group-message.md) for group message
+sending and receiving.
+
 ```
 Creator                        Relay                       Recipient
   |                              |                              |

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -65,6 +65,9 @@ connected client in real time as they arrive, eliminating the need to poll. The 
 connects to this endpoint via `relay_ws_listen_loop` and uses a `Notify` signal to wake the sync
 loop immediately when an envelope arrives, giving near-real-time message delivery.
 
+See [flows/13-relay-websocket.md](flows/13-relay-websocket.md) for a sequence diagram of the
+full push and reconnect flow.
+
 ## Dashboard
 
 The relay serves a built-in HTML dashboard at `/` showing:
@@ -86,6 +89,8 @@ The relay serves a built-in HTML dashboard at `/` showing:
   in duplicate deliveries.
 
 ## How Peers Connect
+
+See [flows/02-peer-reconnect.md](flows/02-peer-reconnect.md) for the full sequence diagram.
 
 Peers connect to the relay using the `RelayClient` (HTTP). The connection flow is:
 


### PR DESCRIPTION
## Summary

This PR adds a new `docs/flows/` directory with 13 detailed Mermaid sequence diagrams documenting all major Tenet protocol flows. Each diagram illustrates the message exchanges between peers, relays, and client components with step-by-step annotations.

## Key Changes

- **New flow documentation** (13 files):
  - `01-add-friend.md` — Friend request handshake and key exchange
  - `02-peer-reconnect.md` — Online announcement, inbox polling, and mesh queries
  - `03-direct-message.md` — HPKE encryption, signing, and delivery
  - `04-store-and-forward.md` — Message routing through mutual friends
  - `05-public-message.md` — Timeline post distribution
  - `06-attachment.md` — Content-addressed file upload and embedding
  - `07-mesh-distribution.md` — Four-way gossip protocol for public message backfill
  - `08-peer-discovery.md` — Public key fetching and verification (TOFU model)
  - `09-profile-updates.md` — Profile push and pull mechanisms
  - `10-group-create-invite.md` — Group creation and consent-based key distribution
  - `11-group-message.md` — Group message encryption and delivery
  - `12-reactions-replies.md` — Reactions and threaded replies
  - `13-relay-websocket.md` — Real-time WebSocket push and local UI events
  - `README.md` — Index and diagram reading guide

- **Updated existing docs** with cross-references:
  - `docs/architecture.md` — Added pointer to flows directory
  - `docs/relay.md` — Added reference to WebSocket flow diagram
  - `docs/groups.md` — Added references to group flow diagrams
  - `docs/friend_requests.md` — Added reference to friend request flow diagram

## Implementation Details

- Each flow diagram uses Mermaid's `sequenceDiagram` syntax with:
  - Colored `rect` blocks to group related steps
  - Participant roles (Peer, Relay, Browser, SQLite, etc.)
  - Annotations explaining cryptographic operations and state transitions
  - Alternative paths (e.g., WebSocket push vs. polling, accept/ignore/block variants)
  
- Diagrams include security-relevant details:
  - Key binding guarantees (Peer ID = SHA-256(signing_key))
  - Signature verification flows
  - HPKE and ChaCha20Poly1305 encryption steps
  - Trust-on-first-use (TOFU) key distribution model

- Cross-references between flows enable readers to understand dependencies (e.g., direct messages require the friend request handshake to complete first)

https://claude.ai/code/session_01LUw1unmyYtrFyq8AuqurQ4