### PR TITLE
Implement Phase 3 Android client: peers, friends, groups, profiles

### DIFF
--- a/android/app/app/src/main/java/com/example/tenet/data/TenetRepository.kt
+++ b/android/app/app/src/main/java/com/example/tenet/data/TenetRepository.kt
@@ -2,8 +2,14 @@ package com.example.tenet.data
 
 import android.content.Context
 import com.example.tenet.uniffi.FfiConversation
+import com.example.tenet.uniffi.FfiFriendRequest
+import com.example.tenet.uniffi.FfiGroup
+import com.example.tenet.uniffi.FfiGroupInvite
+import com.example.tenet.uniffi.FfiGroupMember
 import com.example.tenet.uniffi.FfiMessage
+import com.example.tenet.uniffi.FfiNotification
 import com.example.tenet.uniffi.FfiPeer
+import com.example.tenet.uniffi.FfiProfile
 import com.example.tenet.uniffi.FfiReactionSummary
 import com.example.tenet.uniffi.FfiSyncResult
 import com.example.tenet.uniffi.TenetClient
@@ -187,6 +193,10 @@ class TenetRepository @Inject constructor(
         requireClient().listPeers()
     }
 
+    suspend fun getPeer(peerId: String): FfiPeer? = withContext(Dispatchers.IO) {
+        requireClient().getPeer(peerId)
+    }
+
     suspend fun addPeer(
         peerId: String,
         displayName: String?,
@@ -197,5 +207,131 @@ class TenetRepository @Inject constructor(
 
     suspend fun removePeer(peerId: String) = withContext(Dispatchers.IO) {
         requireClient().removePeer(peerId)
+    }
+
+    suspend fun blockPeer(peerId: String) = withContext(Dispatchers.IO) {
+        requireClient().blockPeer(peerId)
+    }
+
+    suspend fun unblockPeer(peerId: String) = withContext(Dispatchers.IO) {
+        requireClient().unblockPeer(peerId)
+    }
+
+    suspend fun mutePeer(peerId: String) = withContext(Dispatchers.IO) {
+        requireClient().mutePeer(peerId)
+    }
+
+    suspend fun unmutePeer(peerId: String) = withContext(Dispatchers.IO) {
+        requireClient().unmutePeer(peerId)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Friends
+    // ---------------------------------------------------------------------------
+
+    suspend fun sendFriendRequest(peerId: String, message: String?) = withContext(Dispatchers.IO) {
+        requireClient().sendFriendRequest(peerId, message)
+    }
+
+    suspend fun listFriendRequests(): List<FfiFriendRequest> = withContext(Dispatchers.IO) {
+        requireClient().listFriendRequests()
+    }
+
+    suspend fun acceptFriendRequest(requestId: Long) = withContext(Dispatchers.IO) {
+        requireClient().acceptFriendRequest(requestId)
+    }
+
+    suspend fun ignoreFriendRequest(requestId: Long) = withContext(Dispatchers.IO) {
+        requireClient().ignoreFriendRequest(requestId)
+    }
+
+    suspend fun blockFriendRequest(requestId: Long) = withContext(Dispatchers.IO) {
+        requireClient().blockFriendRequest(requestId)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Groups
+    // ---------------------------------------------------------------------------
+
+    suspend fun listGroups(): List<FfiGroup> = withContext(Dispatchers.IO) {
+        requireClient().listGroups()
+    }
+
+    suspend fun getGroup(groupId: String): FfiGroup? = withContext(Dispatchers.IO) {
+        requireClient().getGroup(groupId)
+    }
+
+    suspend fun listGroupMembers(groupId: String): List<FfiGroupMember> =
+        withContext(Dispatchers.IO) {
+            requireClient().listGroupMembers(groupId)
+        }
+
+    suspend fun createGroup(memberIds: List<String>): String = withContext(Dispatchers.IO) {
+        requireClient().createGroup(memberIds)
+    }
+
+    suspend fun addGroupMember(groupId: String, peerId: String) = withContext(Dispatchers.IO) {
+        requireClient().addGroupMember(groupId, peerId)
+    }
+
+    suspend fun removeGroupMember(groupId: String, peerId: String) = withContext(Dispatchers.IO) {
+        requireClient().removeGroupMember(groupId, peerId)
+    }
+
+    suspend fun leaveGroup(groupId: String) = withContext(Dispatchers.IO) {
+        requireClient().leaveGroup(groupId)
+    }
+
+    suspend fun listGroupInvites(): List<FfiGroupInvite> = withContext(Dispatchers.IO) {
+        requireClient().listGroupInvites()
+    }
+
+    suspend fun acceptGroupInvite(inviteId: Long) = withContext(Dispatchers.IO) {
+        requireClient().acceptGroupInvite(inviteId)
+    }
+
+    suspend fun ignoreGroupInvite(inviteId: Long) = withContext(Dispatchers.IO) {
+        requireClient().ignoreGroupInvite(inviteId)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Profiles
+    // ---------------------------------------------------------------------------
+
+    suspend fun getOwnProfile(): FfiProfile? = withContext(Dispatchers.IO) {
+        requireClient().getOwnProfile()
+    }
+
+    suspend fun updateOwnProfile(
+        displayName: String?,
+        bio: String?,
+        avatarHash: String?,
+    ) = withContext(Dispatchers.IO) {
+        requireClient().updateOwnProfile(displayName, bio, avatarHash)
+    }
+
+    suspend fun getPeerProfile(peerId: String): FfiProfile? = withContext(Dispatchers.IO) {
+        requireClient().getPeerProfile(peerId)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Notifications
+    // ---------------------------------------------------------------------------
+
+    suspend fun listNotifications(unreadOnly: Boolean = false): List<FfiNotification> =
+        withContext(Dispatchers.IO) {
+            requireClient().listNotifications(unreadOnly)
+        }
+
+    suspend fun notificationCount(): UInt = withContext(Dispatchers.IO) {
+        requireClient().notificationCount()
+    }
+
+    suspend fun markNotificationRead(notificationId: Long) = withContext(Dispatchers.IO) {
+        requireClient().markNotificationRead(notificationId)
+    }
+
+    suspend fun markAllNotificationsRead() = withContext(Dispatchers.IO) {
+        requireClient().markAllNotificationsRead()
     }
 }

--- a/android/app/app/src/main/java/com/example/tenet/ui/friends/FriendsScreen.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/friends/FriendsScreen.kt
@@ -1,0 +1,204 @@
+package com.example.tenet.ui.friends
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.tenet.uniffi.FfiFriendRequest
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FriendsScreen(
+    onPeerClick: (String) -> Unit,
+    onGroupsClick: () -> Unit = {},
+    viewModel: FriendsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.error) {
+        state.error?.let { snackbarHostState.showSnackbar(it); viewModel.clearStatus() }
+    }
+    LaunchedEffect(state.actionSuccess) {
+        state.actionSuccess?.let { snackbarHostState.showSnackbar(it); viewModel.clearStatus() }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Friends") },
+                actions = {
+                    IconButton(onClick = onGroupsClick) {
+                        Icon(Icons.Default.Group, contentDescription = "Groups")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            if (state.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                return@Box
+            }
+
+            if (state.incoming.isEmpty() && state.outgoing.isEmpty()) {
+                Text(
+                    "No friend requests yet. Go to a peer's profile to send one.",
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(24.dp),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                return@Box
+            }
+
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                if (state.incoming.isNotEmpty()) {
+                    item {
+                        SectionHeader("Incoming Requests (${state.incoming.size})")
+                    }
+                    items(state.incoming, key = { it.id }) { req ->
+                        IncomingRequestCard(
+                            request = req,
+                            onAccept = { viewModel.accept(req.id) },
+                            onIgnore = { viewModel.ignore(req.id) },
+                            onBlock = { viewModel.block(req.id) },
+                            onPeerClick = onPeerClick,
+                        )
+                    }
+                }
+
+                if (state.outgoing.isNotEmpty()) {
+                    item {
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                        SectionHeader("Outgoing Requests (${state.outgoing.size})")
+                    }
+                    items(state.outgoing, key = { it.id }) { req ->
+                        OutgoingRequestCard(request = req, onPeerClick = onPeerClick)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun IncomingRequestCard(
+    request: FfiFriendRequest,
+    onAccept: () -> Unit,
+    onIgnore: () -> Unit,
+    onBlock: () -> Unit,
+    onPeerClick: (String) -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = request.fromPeerId.take(20),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            if (!request.message.isNullOrBlank()) {
+                Text(
+                    text = "\"${request.message}\"",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onAccept) { Text("Accept") }
+                OutlinedButton(onClick = onIgnore) { Text("Ignore") }
+                OutlinedButton(
+                    onClick = onBlock,
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) { Text("Block") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OutgoingRequestCard(request: FfiFriendRequest, onPeerClick: (String) -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        onClick = { onPeerClick(request.toPeerId) },
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = request.toPeerId.take(20),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = request.status.replaceFirstChar { it.uppercase() },
+                style = MaterialTheme.typography.labelSmall,
+                color = when (request.status) {
+                    "accepted" -> MaterialTheme.colorScheme.primary
+                    "ignored", "blocked" -> MaterialTheme.colorScheme.error
+                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                },
+            )
+        }
+    }
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/friends/FriendsViewModel.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/friends/FriendsViewModel.kt
@@ -1,0 +1,84 @@
+package com.example.tenet.ui.friends
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.tenet.data.TenetRepository
+import com.example.tenet.uniffi.FfiFriendRequest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class FriendsUiState(
+    val incoming: List<FfiFriendRequest> = emptyList(),
+    val outgoing: List<FfiFriendRequest> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val actionSuccess: String? = null,
+)
+
+@HiltViewModel
+class FriendsViewModel @Inject constructor(
+    private val repository: TenetRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(FriendsUiState())
+    val uiState: StateFlow<FriendsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadRequests()
+    }
+
+    fun loadRequests() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            runCatching { repository.listFriendRequests() }
+                .onSuccess { all ->
+                    _uiState.value = _uiState.value.copy(
+                        incoming = all.filter { it.direction == "incoming" && it.status == "pending" },
+                        outgoing = all.filter { it.direction == "outgoing" },
+                        isLoading = false,
+                    )
+                }
+                .onFailure { e ->
+                    _uiState.value = _uiState.value.copy(isLoading = false, error = e.message)
+                }
+        }
+    }
+
+    fun accept(requestId: Long) {
+        viewModelScope.launch {
+            runCatching { repository.acceptFriendRequest(requestId) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(actionSuccess = "Friend request accepted")
+                    loadRequests()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun ignore(requestId: Long) {
+        viewModelScope.launch {
+            runCatching { repository.ignoreFriendRequest(requestId) }
+                .onSuccess { loadRequests() }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun block(requestId: Long) {
+        viewModelScope.launch {
+            runCatching { repository.blockFriendRequest(requestId) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(actionSuccess = "User blocked")
+                    loadRequests()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun clearStatus() {
+        _uiState.value = _uiState.value.copy(error = null, actionSuccess = null)
+    }
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/groups/GroupDetailScreen.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/groups/GroupDetailScreen.kt
@@ -1,0 +1,228 @@
+package com.example.tenet.ui.groups
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.tenet.uniffi.FfiGroupMember
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroupDetailScreen(
+    onBack: () -> Unit,
+    viewModel: GroupDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showAddMemberDialog by remember { mutableStateOf(false) }
+    var showLeaveConfirm by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.error) {
+        state.error?.let { snackbarHostState.showSnackbar(it); viewModel.clearStatus() }
+    }
+    LaunchedEffect(state.actionSuccess) {
+        state.actionSuccess?.let { snackbarHostState.showSnackbar(it); viewModel.clearStatus() }
+    }
+    LaunchedEffect(state.leftGroup) {
+        if (state.leftGroup) onBack()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Group") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        if (state.isLoading) {
+            Box(Modifier.fillMaxSize().padding(padding)) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+            return@Scaffold
+        }
+
+        val group = state.group
+        if (group == null) {
+            Box(Modifier.fillMaxSize().padding(padding)) {
+                Text("Group not found", modifier = Modifier.align(Alignment.Center))
+            }
+            return@Scaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            item {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text("Group ID", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                    Text(group.groupId, style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "Created by ${group.creatorId.take(16)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                    Text(
+                        "Members (${state.members.size})",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+            }
+
+            items(state.members, key = { it.peerId }) { member ->
+                MemberRow(
+                    member = member,
+                    onRemove = { viewModel.removeMember(member.peerId) },
+                )
+            }
+
+            item {
+                HorizontalDivider(modifier = Modifier.padding(16.dp))
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    OutlinedButton(
+                        onClick = { showAddMemberDialog = true },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text("Add Member") }
+                    OutlinedButton(
+                        onClick = { showLeaveConfirm = true },
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
+                    ) { Text("Leave Group") }
+                }
+            }
+        }
+    }
+
+    if (showAddMemberDialog) {
+        AddMemberDialog(
+            onDismiss = { showAddMemberDialog = false },
+            onConfirm = { peerId ->
+                showAddMemberDialog = false
+                viewModel.addMember(peerId)
+            },
+        )
+    }
+
+    if (showLeaveConfirm) {
+        AlertDialog(
+            onDismissRequest = { showLeaveConfirm = false },
+            title = { Text("Leave Group") },
+            text = { Text("Are you sure you want to leave this group?") },
+            confirmButton = {
+                Button(
+                    onClick = { showLeaveConfirm = false; viewModel.leaveGroup() },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+                ) { Text("Leave") }
+            },
+            dismissButton = { TextButton(onClick = { showLeaveConfirm = false }) { Text("Cancel") } },
+        )
+    }
+}
+
+@Composable
+private fun MemberRow(member: FfiGroupMember, onRemove: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = member.displayName ?: member.peerId.take(20),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            if (member.displayName != null) {
+                Text(
+                    text = member.peerId.take(16),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        TextButton(
+            onClick = onRemove,
+            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+        ) { Text("Remove") }
+    }
+}
+
+@Composable
+private fun AddMemberDialog(onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+    var peerId by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add Member") },
+        text = {
+            OutlinedTextField(
+                value = peerId,
+                onValueChange = { peerId = it },
+                label = { Text("Peer ID") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(peerId.trim()) },
+                enabled = peerId.isNotBlank(),
+            ) { Text("Add") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/groups/GroupDetailViewModel.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/groups/GroupDetailViewModel.kt
@@ -1,0 +1,89 @@
+package com.example.tenet.ui.groups
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.tenet.data.TenetRepository
+import com.example.tenet.uniffi.FfiGroup
+import com.example.tenet.uniffi.FfiGroupMember
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class GroupDetailUiState(
+    val group: FfiGroup? = null,
+    val members: List<FfiGroupMember> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val actionSuccess: String? = null,
+    val leftGroup: Boolean = false,
+)
+
+@HiltViewModel
+class GroupDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val repository: TenetRepository,
+) : ViewModel() {
+
+    private val groupId: String = checkNotNull(savedStateHandle["groupId"])
+
+    private val _uiState = MutableStateFlow(GroupDetailUiState())
+    val uiState: StateFlow<GroupDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            runCatching {
+                val group = repository.getGroup(groupId)
+                val members = repository.listGroupMembers(groupId)
+                Pair(group, members)
+            }.onSuccess { (group, members) ->
+                _uiState.value = _uiState.value.copy(
+                    group = group,
+                    members = members,
+                    isLoading = false,
+                )
+            }.onFailure { e ->
+                _uiState.value = _uiState.value.copy(isLoading = false, error = e.message)
+            }
+        }
+    }
+
+    fun addMember(peerId: String) {
+        viewModelScope.launch {
+            runCatching { repository.addGroupMember(groupId, peerId) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(actionSuccess = "Member added")
+                    load()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun removeMember(peerId: String) {
+        viewModelScope.launch {
+            runCatching { repository.removeGroupMember(groupId, peerId) }
+                .onSuccess { load() }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun leaveGroup() {
+        viewModelScope.launch {
+            runCatching { repository.leaveGroup(groupId) }
+                .onSuccess { _uiState.value = _uiState.value.copy(leftGroup = true) }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun clearStatus() {
+        _uiState.value = _uiState.value.copy(error = null, actionSuccess = null)
+    }
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/groups/GroupsScreen.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/groups/GroupsScreen.kt
@@ -1,0 +1,236 @@
+package com.example.tenet.ui.groups
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.tenet.uniffi.FfiGroup
+import com.example.tenet.uniffi.FfiGroupInvite
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroupsScreen(
+    onGroupClick: (String) -> Unit,
+    viewModel: GroupsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.error) {
+        state.error?.let { snackbarHostState.showSnackbar(it); viewModel.clearStatus() }
+    }
+    LaunchedEffect(state.actionSuccess) {
+        state.actionSuccess?.let { snackbarHostState.showSnackbar(it); viewModel.clearStatus() }
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Groups") }) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = viewModel::showCreateDialog) {
+                Icon(Icons.Default.Add, contentDescription = "Create group")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            if (state.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                return@Box
+            }
+
+            if (state.groups.isEmpty() && state.pendingInvites.isEmpty()) {
+                Text(
+                    "No groups yet. Tap + to create one.",
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(24.dp),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                return@Box
+            }
+
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                if (state.pendingInvites.isNotEmpty()) {
+                    item {
+                        Text(
+                            "Pending Invites",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+                    items(state.pendingInvites, key = { "invite-${it.id}" }) { invite ->
+                        GroupInviteCard(
+                            invite = invite,
+                            onAccept = { viewModel.acceptInvite(invite.id) },
+                            onIgnore = { viewModel.ignoreInvite(invite.id) },
+                        )
+                    }
+                    item { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
+                }
+
+                if (state.groups.isNotEmpty()) {
+                    item {
+                        Text(
+                            "My Groups",
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+                    items(state.groups, key = { it.groupId }) { group ->
+                        GroupCard(group = group, onClick = { onGroupClick(group.groupId) })
+                    }
+                }
+            }
+        }
+    }
+
+    if (state.showCreateDialog) {
+        CreateGroupDialog(
+            onDismiss = viewModel::hideCreateDialog,
+            onConfirm = { memberIds -> viewModel.createGroup(memberIds) },
+        )
+    }
+}
+
+@Composable
+private fun GroupCard(group: FfiGroup, onClick: () -> Unit) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Group,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = group.groupId.take(16),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = "${group.memberCount} member${if (group.memberCount != 1u) "s" else ""}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupInviteCard(
+    invite: FfiGroupInvite,
+    onAccept: () -> Unit,
+    onIgnore: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = "Invite from ${invite.fromPeerId.take(16)}",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = "Group: ${invite.groupId.take(16)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onAccept) { Text("Join") }
+                OutlinedButton(onClick = onIgnore) { Text("Ignore") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CreateGroupDialog(onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+    var memberIds by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Create Group") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    "Enter peer IDs of members to add, separated by commas.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                OutlinedTextField(
+                    value = memberIds,
+                    onValueChange = { memberIds = it },
+                    label = { Text("Peer IDs (comma-separated)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2,
+                    maxLines = 4,
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = { onConfirm(memberIds) }) { Text("Create") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/groups/GroupsViewModel.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/groups/GroupsViewModel.kt
@@ -1,0 +1,102 @@
+package com.example.tenet.ui.groups
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.tenet.data.TenetRepository
+import com.example.tenet.uniffi.FfiGroup
+import com.example.tenet.uniffi.FfiGroupInvite
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class GroupsUiState(
+    val groups: List<FfiGroup> = emptyList(),
+    val pendingInvites: List<FfiGroupInvite> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val actionSuccess: String? = null,
+    val showCreateDialog: Boolean = false,
+)
+
+@HiltViewModel
+class GroupsViewModel @Inject constructor(
+    private val repository: TenetRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(GroupsUiState())
+    val uiState: StateFlow<GroupsUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            runCatching {
+                val groups = repository.listGroups()
+                val invites = repository.listGroupInvites()
+                    .filter { it.direction == "incoming" && it.status == "pending" }
+                Pair(groups, invites)
+            }.onSuccess { (groups, invites) ->
+                _uiState.value = _uiState.value.copy(
+                    groups = groups,
+                    pendingInvites = invites,
+                    isLoading = false,
+                )
+            }.onFailure { e ->
+                _uiState.value = _uiState.value.copy(isLoading = false, error = e.message)
+            }
+        }
+    }
+
+    fun showCreateDialog() {
+        _uiState.value = _uiState.value.copy(showCreateDialog = true)
+    }
+
+    fun hideCreateDialog() {
+        _uiState.value = _uiState.value.copy(showCreateDialog = false)
+    }
+
+    /** memberIds is a comma-separated string of peer IDs entered by the user. */
+    fun createGroup(memberIdsRaw: String) {
+        val memberIds = memberIdsRaw.split(",").map { it.trim() }.filter { it.isNotBlank() }
+        viewModelScope.launch {
+            runCatching { repository.createGroup(memberIds) }
+                .onSuccess { groupId ->
+                    _uiState.value = _uiState.value.copy(
+                        showCreateDialog = false,
+                        actionSuccess = "Group created: $groupId",
+                    )
+                    load()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun acceptInvite(inviteId: Long) {
+        viewModelScope.launch {
+            runCatching { repository.acceptGroupInvite(inviteId) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(actionSuccess = "Joined group")
+                    load()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun ignoreInvite(inviteId: Long) {
+        viewModelScope.launch {
+            runCatching { repository.ignoreGroupInvite(inviteId) }
+                .onSuccess { load() }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun clearStatus() {
+        _uiState.value = _uiState.value.copy(error = null, actionSuccess = null)
+    }
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/peers/PeerDetailScreen.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/peers/PeerDetailScreen.kt
@@ -1,0 +1,238 @@
+package com.example.tenet.ui.peers
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PeerDetailScreen(
+    onBack: () -> Unit,
+    onSendMessage: (String) -> Unit,
+    viewModel: PeerDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showFriendRequestDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.error) {
+        state.error?.let { snackbarHostState.showSnackbar(it); viewModel.clearStatus() }
+    }
+    LaunchedEffect(state.actionSuccess) {
+        state.actionSuccess?.let { snackbarHostState.showSnackbar(it); viewModel.clearStatus() }
+    }
+
+    val peer = state.peer
+    val profile = state.profile
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(peer?.displayName ?: peer?.peerId?.take(16) ?: "Peer") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        if (state.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+            ) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+            return@Scaffold
+        }
+
+        if (peer == null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+            ) {
+                Text("Peer not found", modifier = Modifier.align(Alignment.Center))
+            }
+            return@Scaffold
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // --- Identity ---
+            Text("Peer ID", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+            Text(peer.peerId, style = MaterialTheme.typography.bodyMedium)
+
+            if (profile != null) {
+                HorizontalDivider()
+                if (profile.bio != null) {
+                    Text("Bio", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                    Text(profile.bio, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+
+            HorizontalDivider()
+
+            // --- Status badges ---
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                StatusChip(
+                    label = if (peer.isOnline) "Online" else "Offline",
+                    active = peer.isOnline,
+                )
+                if (peer.isFriend) StatusChip("Friend", active = true)
+                if (peer.isBlocked) StatusChip("Blocked", active = true, isError = true)
+                if (peer.isMuted) StatusChip("Muted", active = true)
+            }
+
+            HorizontalDivider()
+            Spacer(Modifier.height(4.dp))
+
+            // --- Actions ---
+            Button(
+                onClick = { onSendMessage(peer.peerId) },
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text("Send Message") }
+
+            if (!peer.isFriend && state.pendingOutgoingRequest == null) {
+                OutlinedButton(
+                    onClick = { showFriendRequestDialog = true },
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Send Friend Request") }
+            } else if (state.pendingOutgoingRequest != null) {
+                OutlinedButton(
+                    onClick = {},
+                    enabled = false,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Friend Request Pending") }
+            }
+
+            if (peer.isBlocked) {
+                OutlinedButton(
+                    onClick = viewModel::unblock,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Unblock") }
+            } else {
+                OutlinedButton(
+                    onClick = viewModel::block,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                ) { Text("Block") }
+            }
+
+            if (peer.isMuted) {
+                OutlinedButton(
+                    onClick = viewModel::unmute,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Unmute") }
+            } else {
+                OutlinedButton(
+                    onClick = viewModel::mute,
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text("Mute") }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            TextButton(
+                onClick = { viewModel.remove(); onBack() },
+                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                modifier = Modifier.fillMaxWidth(),
+            ) { Text("Remove Peer") }
+        }
+    }
+
+    if (showFriendRequestDialog) {
+        FriendRequestDialog(
+            onDismiss = { showFriendRequestDialog = false },
+            onConfirm = { msg ->
+                showFriendRequestDialog = false
+                viewModel.sendFriendRequest(msg)
+            },
+        )
+    }
+}
+
+@Composable
+private fun StatusChip(label: String, active: Boolean, isError: Boolean = false) {
+    val color = when {
+        isError -> MaterialTheme.colorScheme.error
+        active -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelMedium,
+        fontWeight = FontWeight.SemiBold,
+        color = color,
+    )
+}
+
+@Composable
+private fun FriendRequestDialog(onDismiss: () -> Unit, onConfirm: (String?) -> Unit) {
+    var message by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Send Friend Request") },
+        text = {
+            OutlinedTextField(
+                value = message,
+                onValueChange = { message = it },
+                label = { Text("Message (optional)") },
+                modifier = Modifier.fillMaxWidth(),
+                maxLines = 3,
+            )
+        },
+        confirmButton = {
+            Button(onClick = { onConfirm(message.ifBlank { null }) }) { Text("Send") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/peers/PeerDetailViewModel.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/peers/PeerDetailViewModel.kt
@@ -1,0 +1,132 @@
+package com.example.tenet.ui.peers
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.tenet.data.TenetRepository
+import com.example.tenet.uniffi.FfiFriendRequest
+import com.example.tenet.uniffi.FfiPeer
+import com.example.tenet.uniffi.FfiProfile
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class PeerDetailUiState(
+    val peer: FfiPeer? = null,
+    val profile: FfiProfile? = null,
+    val pendingOutgoingRequest: FfiFriendRequest? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val actionSuccess: String? = null,
+)
+
+@HiltViewModel
+class PeerDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val repository: TenetRepository,
+) : ViewModel() {
+
+    private val peerId: String = checkNotNull(savedStateHandle["peerId"])
+
+    private val _uiState = MutableStateFlow(PeerDetailUiState())
+    val uiState: StateFlow<PeerDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            runCatching {
+                val peer = repository.getPeer(peerId)
+                val profile = repository.getPeerProfile(peerId)
+                val requests = repository.listFriendRequests()
+                val pending = requests.firstOrNull {
+                    it.direction == "outgoing" &&
+                        it.toPeerId == peerId &&
+                        it.status == "pending"
+                }
+                Triple(peer, profile, pending)
+            }.onSuccess { (peer, profile, pending) ->
+                _uiState.value = _uiState.value.copy(
+                    peer = peer,
+                    profile = profile,
+                    pendingOutgoingRequest = pending,
+                    isLoading = false,
+                )
+            }.onFailure { e ->
+                _uiState.value = _uiState.value.copy(isLoading = false, error = e.message)
+            }
+        }
+    }
+
+    fun block() {
+        viewModelScope.launch {
+            runCatching { repository.blockPeer(peerId) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(actionSuccess = "Peer blocked")
+                    load()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun unblock() {
+        viewModelScope.launch {
+            runCatching { repository.unblockPeer(peerId) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(actionSuccess = "Peer unblocked")
+                    load()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun mute() {
+        viewModelScope.launch {
+            runCatching { repository.mutePeer(peerId) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(actionSuccess = "Peer muted")
+                    load()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun unmute() {
+        viewModelScope.launch {
+            runCatching { repository.unmutePeer(peerId) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(actionSuccess = "Peer unmuted")
+                    load()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun sendFriendRequest(message: String?) {
+        viewModelScope.launch {
+            runCatching { repository.sendFriendRequest(peerId, message?.ifBlank { null }) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(actionSuccess = "Friend request sent")
+                    load()
+                }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun remove() {
+        viewModelScope.launch {
+            runCatching { repository.removePeer(peerId) }
+                .onFailure { e -> _uiState.value = _uiState.value.copy(error = e.message) }
+        }
+    }
+
+    fun clearStatus() {
+        _uiState.value = _uiState.value.copy(error = null, actionSuccess = null)
+    }
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/peers/PeersScreen.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/peers/PeersScreen.kt
@@ -1,0 +1,205 @@
+package com.example.tenet.ui.peers
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Circle
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.tenet.uniffi.FfiPeer
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PeersScreen(
+    onPeerClick: (String) -> Unit,
+    viewModel: PeersViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.error) {
+        state.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Peers") }) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = viewModel::showAddPeerDialog) {
+                Icon(Icons.Default.Add, contentDescription = "Add peer")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            if (state.isLoading && state.peers.isEmpty()) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            } else if (state.peers.isEmpty()) {
+                Text(
+                    "No peers yet. Tap + to add one.",
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(24.dp),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                LazyColumn {
+                    items(state.peers, key = { it.peerId }) { peer ->
+                        PeerRow(peer = peer, onClick = { onPeerClick(peer.peerId) })
+                    }
+                }
+            }
+        }
+    }
+
+    if (state.showAddDialog) {
+        AddPeerDialog(
+            onDismiss = viewModel::hideAddPeerDialog,
+            onConfirm = { peerId, displayName, key -> viewModel.addPeer(peerId, displayName, key) },
+        )
+    }
+}
+
+@Composable
+private fun PeerRow(peer: FfiPeer, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Circle,
+            contentDescription = if (peer.isOnline) "Online" else "Offline",
+            tint = if (peer.isOnline) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.outlineVariant,
+            modifier = Modifier.size(10.dp),
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = peer.displayName ?: peer.peerId.take(16),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            if (peer.displayName != null) {
+                Text(
+                    text = peer.peerId.take(20),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            if (peer.isFriend) BadgeLabel("Friend")
+            if (peer.isBlocked) BadgeLabel("Blocked", error = true)
+            if (peer.isMuted) BadgeLabel("Muted")
+        }
+    }
+}
+
+@Composable
+private fun BadgeLabel(label: String, error: Boolean = false) {
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelSmall,
+        color = if (error) MaterialTheme.colorScheme.error
+        else MaterialTheme.colorScheme.primary,
+    )
+}
+
+@Composable
+private fun AddPeerDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (peerId: String, displayName: String?, signingKey: String) -> Unit,
+) {
+    var peerId by remember { mutableStateOf("") }
+    var displayName by remember { mutableStateOf("") }
+    var signingKey by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add Peer") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = peerId,
+                    onValueChange = { peerId = it },
+                    label = { Text("Peer ID") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = displayName,
+                    onValueChange = { displayName = it },
+                    label = { Text("Display name (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = signingKey,
+                    onValueChange = { signingKey = it },
+                    label = { Text("Signing public key (hex)") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(peerId.trim(), displayName.ifBlank { null }, signingKey.trim()) },
+                enabled = peerId.isNotBlank() && signingKey.isNotBlank(),
+            ) { Text("Add") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/peers/PeersViewModel.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/peers/PeersViewModel.kt
@@ -1,0 +1,76 @@
+package com.example.tenet.ui.peers
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.tenet.data.TenetRepository
+import com.example.tenet.uniffi.FfiPeer
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class PeersUiState(
+    val peers: List<FfiPeer> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val showAddDialog: Boolean = false,
+)
+
+@HiltViewModel
+class PeersViewModel @Inject constructor(
+    private val repository: TenetRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PeersUiState())
+    val uiState: StateFlow<PeersUiState> = _uiState.asStateFlow()
+
+    init {
+        loadPeers()
+    }
+
+    fun loadPeers() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            runCatching { repository.listPeers() }
+                .onSuccess { peers ->
+                    _uiState.value = _uiState.value.copy(
+                        peers = peers.sortedWith(
+                            compareByDescending<FfiPeer> { it.isOnline }
+                                .thenBy { it.displayName ?: it.peerId }
+                        ),
+                        isLoading = false,
+                    )
+                }
+                .onFailure { e ->
+                    _uiState.value = _uiState.value.copy(isLoading = false, error = e.message)
+                }
+        }
+    }
+
+    fun showAddPeerDialog() {
+        _uiState.value = _uiState.value.copy(showAddDialog = true)
+    }
+
+    fun hideAddPeerDialog() {
+        _uiState.value = _uiState.value.copy(showAddDialog = false)
+    }
+
+    fun addPeer(peerId: String, displayName: String?, signingKeyHex: String) {
+        viewModelScope.launch {
+            runCatching { repository.addPeer(peerId, displayName?.ifBlank { null }, signingKeyHex) }
+                .onSuccess {
+                    _uiState.value = _uiState.value.copy(showAddDialog = false)
+                    loadPeers()
+                }
+                .onFailure { e ->
+                    _uiState.value = _uiState.value.copy(error = e.message)
+                }
+        }
+    }
+
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(error = null)
+    }
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/profile/ProfileScreen.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/profile/ProfileScreen.kt
@@ -1,0 +1,188 @@
+package com.example.tenet.ui.profile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(
+    viewModel: ProfileViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Edit-form fields — seeded from profile when editing begins.
+    var editDisplayName by rememberSaveable { mutableStateOf("") }
+    var editBio by rememberSaveable { mutableStateOf("") }
+
+    LaunchedEffect(state.error) {
+        state.error?.let { snackbarHostState.showSnackbar(it); viewModel.clearStatus() }
+    }
+    LaunchedEffect(state.saveSuccess) {
+        if (state.saveSuccess) {
+            snackbarHostState.showSnackbar("Profile saved")
+            viewModel.clearStatus()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Profile") },
+                actions = {
+                    if (!state.isEditing && !state.isLoading) {
+                        IconButton(onClick = {
+                            editDisplayName = state.profile?.displayName ?: ""
+                            editBio = state.profile?.bio ?: ""
+                            viewModel.startEditing()
+                        }) {
+                            Icon(Icons.Default.Edit, contentDescription = "Edit profile")
+                        }
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            if (state.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                return@Box
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                // --- Peer ID (always read-only) ---
+                Text("Peer ID", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.primary)
+                Text(
+                    state.myPeerId,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                )
+                HorizontalDivider()
+
+                if (state.isEditing) {
+                    // --- Edit form ---
+                    OutlinedTextField(
+                        value = editDisplayName,
+                        onValueChange = { editDisplayName = it },
+                        label = { Text("Display name") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    OutlinedTextField(
+                        value = editBio,
+                        onValueChange = { editBio = it },
+                        label = { Text("Bio") },
+                        modifier = Modifier.fillMaxWidth(),
+                        minLines = 3,
+                        maxLines = 6,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Button(
+                        onClick = { viewModel.saveProfile(editDisplayName, editBio) },
+                        enabled = !state.isSaving,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        if (state.isSaving) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.height(18.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Text("Save")
+                        }
+                    }
+                    OutlinedButton(
+                        onClick = viewModel::cancelEditing,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text("Cancel") }
+                } else {
+                    // --- Read-only view ---
+                    val profile = state.profile
+                    if (profile == null) {
+                        Text(
+                            "No profile set yet. Tap the edit button to add your display name and bio.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    } else {
+                        if (profile.displayName != null) {
+                            ProfileField("Display name", profile.displayName)
+                        }
+                        if (profile.bio != null) {
+                            ProfileField("Bio", profile.bio)
+                        }
+                        if (profile.displayName == null && profile.bio == null) {
+                            Text(
+                                "Profile is empty. Tap the edit button to fill it in.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileField(label: String, value: String) {
+    Column {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(value, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/profile/ProfileViewModel.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/profile/ProfileViewModel.kt
@@ -1,0 +1,84 @@
+package com.example.tenet.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.tenet.data.TenetRepository
+import com.example.tenet.uniffi.FfiProfile
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class ProfileUiState(
+    val profile: FfiProfile? = null,
+    val myPeerId: String = "",
+    val isLoading: Boolean = false,
+    val isSaving: Boolean = false,
+    val isEditing: Boolean = false,
+    val error: String? = null,
+    val saveSuccess: Boolean = false,
+)
+
+@HiltViewModel
+class ProfileViewModel @Inject constructor(
+    private val repository: TenetRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ProfileUiState())
+    val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            runCatching {
+                val myId = repository.myPeerId()
+                val profile = repository.getOwnProfile()
+                Pair(myId, profile)
+            }.onSuccess { (myId, profile) ->
+                _uiState.value = _uiState.value.copy(
+                    myPeerId = myId,
+                    profile = profile,
+                    isLoading = false,
+                )
+            }.onFailure { e ->
+                _uiState.value = _uiState.value.copy(isLoading = false, error = e.message)
+            }
+        }
+    }
+
+    fun startEditing() {
+        _uiState.value = _uiState.value.copy(isEditing = true, saveSuccess = false)
+    }
+
+    fun cancelEditing() {
+        _uiState.value = _uiState.value.copy(isEditing = false)
+    }
+
+    fun saveProfile(displayName: String?, bio: String?) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSaving = true, error = null)
+            runCatching {
+                repository.updateOwnProfile(
+                    displayName = displayName?.ifBlank { null },
+                    bio = bio?.ifBlank { null },
+                    avatarHash = null, // avatar upload handled separately via attachment API
+                )
+            }.onSuccess {
+                _uiState.value = _uiState.value.copy(isSaving = false, isEditing = false, saveSuccess = true)
+                load()
+            }.onFailure { e ->
+                _uiState.value = _uiState.value.copy(isSaving = false, error = e.message)
+            }
+        }
+    }
+
+    fun clearStatus() {
+        _uiState.value = _uiState.value.copy(error = null, saveSuccess = false)
+    }
+}

--- a/android/tenet-ffi/src/lib.rs
+++ b/android/tenet-ffi/src/lib.rs
@@ -27,9 +27,15 @@ use tenet::protocol::{
     MessageKind,
 };
 use tenet::relay_transport::post_envelope;
-use tenet::storage::{AttachmentRow, PeerRow, ReactionRow, Storage};
+use tenet::storage::{
+    AttachmentRow, FriendRequestRow, GroupInviteRow, GroupMemberRow, GroupRow, NotificationRow,
+    PeerRow, ProfileRow, ReactionRow, Storage,
+};
 
-pub use types::{FfiConversation, FfiMessage, FfiPeer, FfiReactionSummary, FfiSyncResult};
+pub use types::{
+    FfiConversation, FfiFriendRequest, FfiGroup, FfiGroupInvite, FfiGroupMember, FfiMessage,
+    FfiNotification, FfiPeer, FfiProfile, FfiReactionSummary, FfiSyncResult,
+};
 
 // HPKE binding strings — must match the web client constants so messages
 // created by the web client can be decrypted by the Android client and
@@ -605,16 +611,17 @@ impl TenetClient {
             .list_peers()
             .map_err(|e| TenetError::Storage(e.to_string()))?
             .into_iter()
-            .map(|p| FfiPeer {
-                peer_id: p.peer_id,
-                display_name: p.display_name,
-                is_online: p.online,
-                is_blocked: p.is_blocked,
-                is_muted: p.is_muted,
-                is_friend: p.is_friend,
-                last_seen: p.last_seen_online.map(|t| t as i64),
-            })
+            .map(peer_row_to_ffi)
             .collect())
+    }
+
+    pub fn get_peer(&self, peer_id: String) -> Result<Option<FfiPeer>, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        Ok(inner
+            .storage
+            .get_peer(&peer_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?
+            .map(peer_row_to_ffi))
     }
 
     pub fn add_peer(
@@ -657,6 +664,526 @@ impl TenetClient {
             .map_err(|e| TenetError::Storage(e.to_string()))?;
         Ok(())
     }
+
+    pub fn block_peer(&self, peer_id: String) -> Result<(), TenetError> {
+        self.inner
+            .lock()
+            .unwrap()
+            .storage
+            .set_peer_blocked(&peer_id, true)
+            .map_err(|e| TenetError::Storage(e.to_string()))
+    }
+
+    pub fn unblock_peer(&self, peer_id: String) -> Result<(), TenetError> {
+        self.inner
+            .lock()
+            .unwrap()
+            .storage
+            .set_peer_blocked(&peer_id, false)
+            .map_err(|e| TenetError::Storage(e.to_string()))
+    }
+
+    pub fn mute_peer(&self, peer_id: String) -> Result<(), TenetError> {
+        self.inner
+            .lock()
+            .unwrap()
+            .storage
+            .set_peer_muted(&peer_id, true)
+            .map_err(|e| TenetError::Storage(e.to_string()))
+    }
+
+    pub fn unmute_peer(&self, peer_id: String) -> Result<(), TenetError> {
+        self.inner
+            .lock()
+            .unwrap()
+            .storage
+            .set_peer_muted(&peer_id, false)
+            .map_err(|e| TenetError::Storage(e.to_string()))
+    }
+
+    // -------------------------------------------------------------------------
+    // Friends
+    // -------------------------------------------------------------------------
+
+    pub fn send_friend_request(
+        &self,
+        peer_id: String,
+        message: Option<String>,
+    ) -> Result<(), TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let my_id = inner.keypair.id.clone();
+
+        // Look up the peer so we have keys to fill in the request row.
+        let peer = inner
+            .storage
+            .get_peer(&peer_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?
+            .ok_or_else(|| TenetError::NotFound(format!("peer: {peer_id}")))?;
+
+        let now = now_secs();
+
+        // Upsert: refresh if a request already exists, otherwise insert fresh.
+        if let Ok(Some(existing)) = inner.storage.find_request_between(&my_id, &peer_id) {
+            inner
+                .storage
+                .refresh_friend_request(
+                    existing.id,
+                    message.as_deref(),
+                    &inner.keypair.signing_public_key_hex,
+                    &inner.keypair.public_key_hex,
+                )
+                .map_err(|e| TenetError::Storage(e.to_string()))?;
+        } else {
+            inner
+                .storage
+                .insert_friend_request(&FriendRequestRow {
+                    id: 0,
+                    from_peer_id: my_id.clone(),
+                    to_peer_id: peer_id.clone(),
+                    status: "pending".to_string(),
+                    message: message.clone(),
+                    from_signing_key: inner.keypair.signing_public_key_hex.clone(),
+                    from_encryption_key: inner.keypair.public_key_hex.clone(),
+                    direction: "outgoing".to_string(),
+                    created_at: now,
+                    updated_at: now,
+                })
+                .map_err(|e| TenetError::Storage(e.to_string()))?;
+        }
+
+        // Best-effort: send an encrypted notification to the peer.
+        let notify_body = serde_json::json!({
+            "type": "friend_request",
+            "from": &my_id,
+            "message": message,
+            "signing_key": &inner.keypair.signing_public_key_hex,
+            "encryption_key": &inner.keypair.public_key_hex,
+        })
+        .to_string();
+        let enc_key_hex = peer
+            .encryption_public_key
+            .as_deref()
+            .unwrap_or(&peer.signing_public_key)
+            .to_string();
+        let relay = RelayClient::new(inner.keypair.clone(), client_config(&inner.relay_url));
+        let _ = relay.send_message(&peer_id, &enc_key_hex, &notify_body);
+
+        Ok(())
+    }
+
+    pub fn list_friend_requests(&self) -> Result<Vec<FfiFriendRequest>, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let rows = inner
+            .storage
+            .list_friend_requests(None, None)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(rows.into_iter().map(friend_request_to_ffi).collect())
+    }
+
+    pub fn accept_friend_request(&self, request_id: i64) -> Result<(), TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let req = inner
+            .storage
+            .get_friend_request(request_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?
+            .ok_or_else(|| TenetError::NotFound(format!("friend_request: {request_id}")))?;
+
+        inner
+            .storage
+            .update_friend_request_status(request_id, "accepted")
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+
+        // Mark the sending peer as a friend by re-inserting with is_friend=true.
+        // Use INSERT OR REPLACE to update all fields atomically.
+        let from_id = req.from_peer_id.clone();
+        let now = now_secs();
+        if let Ok(Some(existing_peer)) = inner.storage.get_peer(&from_id) {
+            inner
+                .storage
+                .insert_peer(&PeerRow {
+                    is_friend: true,
+                    ..existing_peer
+                })
+                .map_err(|e| TenetError::Storage(e.to_string()))?;
+        } else {
+            // Peer not in DB yet — add them using keys from the request.
+            inner
+                .storage
+                .insert_peer(&PeerRow {
+                    peer_id: from_id,
+                    display_name: None,
+                    signing_public_key: req.from_signing_key,
+                    encryption_public_key: Some(req.from_encryption_key),
+                    added_at: now,
+                    is_friend: true,
+                    last_seen_online: None,
+                    online: false,
+                    last_profile_requested_at: None,
+                    last_profile_responded_at: None,
+                    is_blocked: false,
+                    is_muted: false,
+                    blocked_at: None,
+                    muted_at: None,
+                })
+                .map_err(|e| TenetError::Storage(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn ignore_friend_request(&self, request_id: i64) -> Result<(), TenetError> {
+        self.inner
+            .lock()
+            .unwrap()
+            .storage
+            .update_friend_request_status(request_id, "ignored")
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    pub fn block_friend_request(&self, request_id: i64) -> Result<(), TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let req = inner
+            .storage
+            .get_friend_request(request_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?
+            .ok_or_else(|| TenetError::NotFound(format!("friend_request: {request_id}")))?;
+
+        inner
+            .storage
+            .update_friend_request_status(request_id, "blocked")
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+
+        // Also block the peer at the peer level.
+        inner
+            .storage
+            .set_peer_blocked(&req.from_peer_id, true)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Groups
+    // -------------------------------------------------------------------------
+
+    pub fn list_groups(&self) -> Result<Vec<FfiGroup>, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let groups = inner
+            .storage
+            .list_groups()
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        let mut result = Vec::with_capacity(groups.len());
+        for g in groups {
+            let members = inner
+                .storage
+                .list_group_members(&g.group_id)
+                .unwrap_or_default();
+            result.push(FfiGroup {
+                group_id: g.group_id,
+                creator_id: g.creator_id,
+                member_count: members.len() as u32,
+                created_at: g.created_at as i64,
+            });
+        }
+        Ok(result)
+    }
+
+    pub fn get_group(&self, group_id: String) -> Result<Option<FfiGroup>, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let group = inner
+            .storage
+            .get_group(&group_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        match group {
+            None => Ok(None),
+            Some(g) => {
+                let members = inner
+                    .storage
+                    .list_group_members(&g.group_id)
+                    .unwrap_or_default();
+                Ok(Some(FfiGroup {
+                    group_id: g.group_id,
+                    creator_id: g.creator_id,
+                    member_count: members.len() as u32,
+                    created_at: g.created_at as i64,
+                }))
+            }
+        }
+    }
+
+    pub fn list_group_members(&self, group_id: String) -> Result<Vec<FfiGroupMember>, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let members = inner
+            .storage
+            .list_group_members(&group_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        let result = members
+            .into_iter()
+            .map(|m| {
+                let display_name = inner
+                    .storage
+                    .get_peer(&m.peer_id)
+                    .ok()
+                    .flatten()
+                    .and_then(|p| p.display_name);
+                FfiGroupMember {
+                    group_id: m.group_id,
+                    peer_id: m.peer_id,
+                    display_name,
+                    joined_at: m.joined_at as i64,
+                }
+            })
+            .collect();
+        Ok(result)
+    }
+
+    pub fn create_group(&self, member_ids: Vec<String>) -> Result<String, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let my_id = inner.keypair.id.clone();
+        let now = now_secs();
+
+        // Generate a random group ID.
+        let mut id_bytes = [0u8; 16];
+        rand::rngs::OsRng.fill_bytes(&mut id_bytes);
+        let group_id = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(id_bytes);
+
+        // Generate a random 32-byte group key.
+        let mut group_key = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut group_key);
+
+        let group_row = GroupRow {
+            group_id: group_id.clone(),
+            group_key: group_key.to_vec(),
+            creator_id: my_id.clone(),
+            created_at: now,
+            key_version: 0,
+        };
+
+        // Build member rows (include the creator).
+        let mut members: Vec<GroupMemberRow> = member_ids
+            .iter()
+            .map(|pid| GroupMemberRow {
+                group_id: group_id.clone(),
+                peer_id: pid.clone(),
+                joined_at: now,
+            })
+            .collect();
+        if !member_ids.contains(&my_id) {
+            members.push(GroupMemberRow {
+                group_id: group_id.clone(),
+                peer_id: my_id,
+                joined_at: now,
+            });
+        }
+
+        inner
+            .storage
+            .insert_group_with_members(&group_row, &members)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+
+        Ok(group_id)
+    }
+
+    pub fn add_group_member(&self, group_id: String, peer_id: String) -> Result<(), TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let now = now_secs();
+        inner
+            .storage
+            .insert_group_member(&GroupMemberRow {
+                group_id,
+                peer_id,
+                joined_at: now,
+            })
+            .map_err(|e| TenetError::Storage(e.to_string()))
+    }
+
+    pub fn remove_group_member(
+        &self,
+        group_id: String,
+        peer_id: String,
+    ) -> Result<(), TenetError> {
+        self.inner
+            .lock()
+            .unwrap()
+            .storage
+            .remove_group_member(&group_id, &peer_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    pub fn leave_group(&self, group_id: String) -> Result<(), TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let my_id = inner.keypair.id.clone();
+        // Remove self from the member list, then delete the group record if no one is left.
+        let _ = inner.storage.remove_group_member(&group_id, &my_id);
+        let remaining = inner
+            .storage
+            .list_group_members(&group_id)
+            .unwrap_or_default();
+        if remaining.is_empty() {
+            let _ = inner.storage.delete_group(&group_id);
+        }
+        Ok(())
+    }
+
+    pub fn list_group_invites(&self) -> Result<Vec<FfiGroupInvite>, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let rows = inner
+            .storage
+            .list_group_invites(None, None)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(rows.into_iter().map(group_invite_to_ffi).collect())
+    }
+
+    pub fn accept_group_invite(&self, invite_id: i64) -> Result<(), TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let invite = inner
+            .storage
+            .get_group_invite(invite_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?
+            .ok_or_else(|| TenetError::NotFound(format!("group_invite: {invite_id}")))?;
+
+        inner
+            .storage
+            .update_group_invite_status(invite_id, "accepted")
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+
+        // Add self as a group member if the group exists.
+        let my_id = inner.keypair.id.clone();
+        let now = now_secs();
+        if inner
+            .storage
+            .get_group(&invite.group_id)
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            let _ = inner.storage.insert_group_member(&GroupMemberRow {
+                group_id: invite.group_id,
+                peer_id: my_id,
+                joined_at: now,
+            });
+        }
+
+        Ok(())
+    }
+
+    pub fn ignore_group_invite(&self, invite_id: i64) -> Result<(), TenetError> {
+        self.inner
+            .lock()
+            .unwrap()
+            .storage
+            .update_group_invite_status(invite_id, "ignored")
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Profiles
+    // -------------------------------------------------------------------------
+
+    pub fn get_own_profile(&self) -> Result<Option<FfiProfile>, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let my_id = inner.keypair.id.clone();
+        let row = inner
+            .storage
+            .get_profile(&my_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(row.map(profile_to_ffi))
+    }
+
+    pub fn update_own_profile(
+        &self,
+        display_name: Option<String>,
+        bio: Option<String>,
+        avatar_hash: Option<String>,
+    ) -> Result<(), TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let my_id = inner.keypair.id.clone();
+        let now = now_secs();
+
+        // Merge with existing profile so unset fields are not wiped.
+        let existing = inner
+            .storage
+            .get_profile(&my_id)
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| ProfileRow {
+                user_id: my_id.clone(),
+                display_name: None,
+                bio: None,
+                avatar_hash: None,
+                public_fields: "{}".to_string(),
+                friends_fields: "{}".to_string(),
+                updated_at: now,
+            });
+
+        let updated = ProfileRow {
+            user_id: my_id,
+            display_name: display_name.or(existing.display_name),
+            bio: bio.or(existing.bio),
+            avatar_hash: avatar_hash.or(existing.avatar_hash),
+            public_fields: existing.public_fields,
+            friends_fields: existing.friends_fields,
+            updated_at: now,
+        };
+
+        inner
+            .storage
+            .upsert_profile(&updated)
+            .map_err(|e| TenetError::Storage(e.to_string()))
+    }
+
+    pub fn get_peer_profile(&self, peer_id: String) -> Result<Option<FfiProfile>, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let row = inner
+            .storage
+            .get_profile(&peer_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(row.map(profile_to_ffi))
+    }
+
+    // -------------------------------------------------------------------------
+    // Notifications
+    // -------------------------------------------------------------------------
+
+    pub fn list_notifications(&self, unread_only: bool) -> Result<Vec<FfiNotification>, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        let rows = inner
+            .storage
+            .list_notifications(unread_only, 200)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(rows.into_iter().map(notification_to_ffi).collect())
+    }
+
+    pub fn notification_count(&self) -> Result<u32, TenetError> {
+        let inner = self.inner.lock().unwrap();
+        inner
+            .storage
+            .count_unread_notifications()
+            .map_err(|e| TenetError::Storage(e.to_string()))
+    }
+
+    pub fn mark_notification_read(&self, notification_id: i64) -> Result<(), TenetError> {
+        self.inner
+            .lock()
+            .unwrap()
+            .storage
+            .mark_notification_read(notification_id)
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(())
+    }
+
+    pub fn mark_all_notifications_read(&self) -> Result<(), TenetError> {
+        self.inner
+            .lock()
+            .unwrap()
+            .storage
+            .mark_all_notifications_read()
+            .map_err(|e| TenetError::Storage(e.to_string()))?;
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -692,6 +1219,66 @@ fn row_to_ffi(r: tenet::storage::MessageRow) -> FfiMessage {
         timestamp: r.timestamp as i64,
         is_read: r.is_read,
         reply_to: r.reply_to,
+    }
+}
+
+fn peer_row_to_ffi(p: PeerRow) -> FfiPeer {
+    FfiPeer {
+        peer_id: p.peer_id,
+        display_name: p.display_name,
+        is_online: p.online,
+        is_blocked: p.is_blocked,
+        is_muted: p.is_muted,
+        is_friend: p.is_friend,
+        last_seen: p.last_seen_online.map(|t| t as i64),
+    }
+}
+
+fn friend_request_to_ffi(r: FriendRequestRow) -> FfiFriendRequest {
+    FfiFriendRequest {
+        id: r.id,
+        from_peer_id: r.from_peer_id,
+        to_peer_id: r.to_peer_id,
+        status: r.status,
+        message: r.message,
+        direction: r.direction,
+        created_at: r.created_at as i64,
+    }
+}
+
+fn group_invite_to_ffi(r: GroupInviteRow) -> FfiGroupInvite {
+    FfiGroupInvite {
+        id: r.id,
+        group_id: r.group_id,
+        from_peer_id: r.from_peer_id,
+        to_peer_id: r.to_peer_id,
+        status: r.status,
+        message: r.message,
+        direction: r.direction,
+        created_at: r.created_at as i64,
+    }
+}
+
+fn profile_to_ffi(r: ProfileRow) -> FfiProfile {
+    FfiProfile {
+        user_id: r.user_id,
+        display_name: r.display_name,
+        bio: r.bio,
+        avatar_hash: r.avatar_hash,
+        public_fields: r.public_fields,
+        friends_fields: r.friends_fields,
+        updated_at: r.updated_at as i64,
+    }
+}
+
+fn notification_to_ffi(r: NotificationRow) -> FfiNotification {
+    FfiNotification {
+        id: r.id,
+        notification_type: r.notification_type,
+        message_id: r.message_id,
+        sender_id: r.sender_id,
+        created_at: r.created_at as i64,
+        is_read: r.read,
     }
 }
 

--- a/android/tenet-ffi/src/tenet_ffi.udl
+++ b/android/tenet-ffi/src/tenet_ffi.udl
@@ -1,6 +1,7 @@
 // UniFFI Interface Definition for Tenet Android FFI
 // Phase 1: Identity init, sync, list/send messages, peer management
 // Phase 2: Conversations, replies, reactions, attachments, group messages
+// Phase 3: Peers detail, friends, groups, profiles, notifications
 
 namespace tenet_ffi {};
 
@@ -65,6 +66,76 @@ dictionary FfiReactionSummary {
     u32 downvotes;
     /// "upvote" | "downvote" | null
     string? my_reaction;
+};
+
+// Phase 3 types ----------------------------------------------------------------
+
+/// An incoming or outgoing friend request.
+dictionary FfiFriendRequest {
+    i64 id;
+    string from_peer_id;
+    string to_peer_id;
+    /// "pending" | "accepted" | "ignored" | "blocked"
+    string status;
+    string? message;
+    /// "incoming" | "outgoing"
+    string direction;
+    i64 created_at;
+};
+
+/// A group the local user is a member of.
+dictionary FfiGroup {
+    string group_id;
+    string creator_id;
+    u32 member_count;
+    i64 created_at;
+};
+
+/// A single group member with display name enrichment.
+dictionary FfiGroupMember {
+    string group_id;
+    string peer_id;
+    string? display_name;
+    i64 joined_at;
+};
+
+/// An incoming or outgoing group invite.
+dictionary FfiGroupInvite {
+    i64 id;
+    string group_id;
+    string from_peer_id;
+    string to_peer_id;
+    /// "pending" | "accepted" | "ignored"
+    string status;
+    string? message;
+    /// "incoming" | "outgoing"
+    string direction;
+    i64 created_at;
+};
+
+/// A user profile.
+dictionary FfiProfile {
+    string user_id;
+    string? display_name;
+    string? bio;
+    /// Content hash — fetch bytes via download_attachment().
+    string? avatar_hash;
+    /// JSON object of public fields (empty object "{}" if none).
+    string public_fields;
+    /// JSON object of friends-only fields (empty object "{}" if none).
+    string friends_fields;
+    i64 updated_at;
+};
+
+/// A single notification entry.
+dictionary FfiNotification {
+    i64 id;
+    /// "direct_message" | "reply" | "reaction" | "friend_request" | "group_invite"
+    string notification_type;
+    string message_id;
+    string sender_id;
+    i64 created_at;
+    boolean is_read;
 };
 
 // ---------------------------------------------------------------------------
@@ -179,9 +250,117 @@ interface TenetClient {
     [Throws=TenetError]
     sequence<FfiPeer> list_peers();
 
+    /// Fetch a single peer by ID, or null if not known.
+    [Throws=TenetError]
+    FfiPeer? get_peer(string peer_id);
+
     [Throws=TenetError]
     void add_peer(string peer_id, string? display_name, string signing_public_key_hex);
 
     [Throws=TenetError]
     void remove_peer(string peer_id);
+
+    [Throws=TenetError]
+    void block_peer(string peer_id);
+
+    [Throws=TenetError]
+    void unblock_peer(string peer_id);
+
+    [Throws=TenetError]
+    void mute_peer(string peer_id);
+
+    [Throws=TenetError]
+    void unmute_peer(string peer_id);
+
+    // ---------------------------------------------------------------------------
+    // Friends
+    // ---------------------------------------------------------------------------
+
+    /// Send a friend request to a known peer.  message is an optional greeting.
+    [Throws=TenetError]
+    void send_friend_request(string peer_id, string? message);
+
+    /// List all friend requests (all directions / statuses).
+    [Throws=TenetError]
+    sequence<FfiFriendRequest> list_friend_requests();
+
+    /// Accept an incoming friend request by its database ID.
+    [Throws=TenetError]
+    void accept_friend_request(i64 request_id);
+
+    /// Ignore (soft-decline) an incoming friend request.
+    [Throws=TenetError]
+    void ignore_friend_request(i64 request_id);
+
+    /// Block the sender of a friend request.
+    [Throws=TenetError]
+    void block_friend_request(i64 request_id);
+
+    // ---------------------------------------------------------------------------
+    // Groups
+    // ---------------------------------------------------------------------------
+
+    [Throws=TenetError]
+    sequence<FfiGroup> list_groups();
+
+    [Throws=TenetError]
+    FfiGroup? get_group(string group_id);
+
+    [Throws=TenetError]
+    sequence<FfiGroupMember> list_group_members(string group_id);
+
+    /// Create a new group.  member_ids must all be known peers.
+    [Throws=TenetError]
+    string create_group(sequence<string> member_ids);
+
+    [Throws=TenetError]
+    void add_group_member(string group_id, string peer_id);
+
+    [Throws=TenetError]
+    void remove_group_member(string group_id, string peer_id);
+
+    /// Leave a group (removes local record; notifies no peers in this implementation).
+    [Throws=TenetError]
+    void leave_group(string group_id);
+
+    [Throws=TenetError]
+    sequence<FfiGroupInvite> list_group_invites();
+
+    [Throws=TenetError]
+    void accept_group_invite(i64 invite_id);
+
+    [Throws=TenetError]
+    void ignore_group_invite(i64 invite_id);
+
+    // ---------------------------------------------------------------------------
+    // Profiles
+    // ---------------------------------------------------------------------------
+
+    /// Get the local user's own profile (null if not yet set).
+    [Throws=TenetError]
+    FfiProfile? get_own_profile();
+
+    /// Create or update the local user's profile.
+    [Throws=TenetError]
+    void update_own_profile(string? display_name, string? bio, string? avatar_hash);
+
+    /// Get a peer's cached profile (null if not yet fetched).
+    [Throws=TenetError]
+    FfiProfile? get_peer_profile(string peer_id);
+
+    // ---------------------------------------------------------------------------
+    // Notifications
+    // ---------------------------------------------------------------------------
+
+    [Throws=TenetError]
+    sequence<FfiNotification> list_notifications(boolean unread_only);
+
+    [Throws=TenetError]
+    u32 notification_count();
+
+    [Throws=TenetError]
+    void mark_notification_read(i64 notification_id);
+
+    [Throws=TenetError]
+    void mark_all_notifications_read();
 };

--- a/android/tenet-ffi/src/types.rs
+++ b/android/tenet-ffi/src/types.rs
@@ -52,3 +52,75 @@ pub struct FfiReactionSummary {
     /// "upvote" | "downvote" | None
     pub my_reaction: Option<String>,
 }
+
+// ---------------------------------------------------------------------------
+// Phase 3 — Social features
+// ---------------------------------------------------------------------------
+
+/// A friend request (incoming or outgoing).
+pub struct FfiFriendRequest {
+    pub id: i64,
+    pub from_peer_id: String,
+    pub to_peer_id: String,
+    /// "pending" | "accepted" | "ignored" | "blocked"
+    pub status: String,
+    pub message: Option<String>,
+    /// "incoming" | "outgoing"
+    pub direction: String,
+    pub created_at: i64,
+}
+
+/// A group the local user belongs to.
+pub struct FfiGroup {
+    pub group_id: String,
+    pub creator_id: String,
+    pub member_count: u32,
+    pub created_at: i64,
+}
+
+/// A single group member.
+pub struct FfiGroupMember {
+    pub group_id: String,
+    pub peer_id: String,
+    pub display_name: Option<String>,
+    pub joined_at: i64,
+}
+
+/// A group invite (incoming or outgoing).
+pub struct FfiGroupInvite {
+    pub id: i64,
+    pub group_id: String,
+    pub from_peer_id: String,
+    pub to_peer_id: String,
+    /// "pending" | "accepted" | "ignored"
+    pub status: String,
+    pub message: Option<String>,
+    /// "incoming" | "outgoing"
+    pub direction: String,
+    pub created_at: i64,
+}
+
+/// A user profile as exposed across the FFI boundary.
+pub struct FfiProfile {
+    pub user_id: String,
+    pub display_name: Option<String>,
+    pub bio: Option<String>,
+    /// Content hash for avatar image (fetch via download_attachment).
+    pub avatar_hash: Option<String>,
+    /// JSON string of public profile fields.
+    pub public_fields: String,
+    /// JSON string of friends-only profile fields.
+    pub friends_fields: String,
+    pub updated_at: i64,
+}
+
+/// A single notification.
+pub struct FfiNotification {
+    pub id: i64,
+    /// "direct_message" | "reply" | "reaction" | "friend_request" | "group_invite"
+    pub notification_type: String,
+    pub message_id: String,
+    pub sender_id: String,
+    pub created_at: i64,
+    pub is_read: bool,
+}


### PR DESCRIPTION
Rust FFI (`android/tenet-ffi/`):
- New FFI types: FfiFriendRequest, FfiGroup, FfiGroupMember, FfiGroupInvite,
  FfiProfile, FfiNotification (types.rs + UDL)
- New TenetClient methods: get_peer, block/unblock/mute/unmute_peer,
  send/list/accept/ignore/block_friend_request, list/get/create_group,
  add/remove_group_member, leave_group, list_group_invites, accept/ignore_group_invite,
  get_own_profile, update_own_profile, get_peer_profile,
  list_notifications, notification_count, mark_notification_read,
  mark_all_notifications_read
- Friend request upsert: refresh existing instead of duplicating
- Group creation: random URL-safe base64 ID + 32-byte OsRng key
- Profile merge: update_own_profile preserves unset fields

Android Kotlin (`android/app/`):
- peers/: PeersScreen (list + add dialog), PeerDetailScreen (block/mute/friend actions)
- friends/: FriendsScreen (incoming accept/ignore/block, outgoing status, Groups link)
- groups/: GroupsScreen (list + invite cards + create dialog), GroupDetailScreen (members)
- profile/: ProfileScreen (read/edit own profile with display name and bio)
- TenetRepository: all Phase 3 suspend functions
- TenetNavHost: 5-item bottom nav (Timeline, Messages, Peers, Friends, Profile);
  new routes peer/{peerId}, group/{groupId}, friends, peers, groups, profile

https://claude.ai/code/session_01EChc38t9mYBu2C77zCJ7w6