### PR TITLE
Android: add multiple identity support with identity switching

### DIFF
--- a/android/app/app/src/main/java/com/example/tenet/data/TenetPreferences.kt
+++ b/android/app/app/src/main/java/com/example/tenet/data/TenetPreferences.kt
@@ -31,8 +31,17 @@ class TenetPreferences @Inject constructor(
             prefs.edit().putString(KEY_WRAPPED_DEK, encoded).apply()
         }
 
+    /**
+     * Short ID of the currently active identity.  Null means use the Rust-layer
+     * default (whichever identity is recorded in config.toml).
+     */
+    var activeIdentityShortId: String?
+        get() = prefs.getString(KEY_ACTIVE_IDENTITY, null)
+        set(value) = prefs.edit().putString(KEY_ACTIVE_IDENTITY, value).apply()
+
     companion object {
         private const val KEY_RELAY_URL = "relay_url"
         private const val KEY_WRAPPED_DEK = "wrapped_dek"
+        private const val KEY_ACTIVE_IDENTITY = "active_identity_short_id"
     }
 }

--- a/android/app/app/src/main/java/com/example/tenet/ui/TenetNavHost.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/TenetNavHost.kt
@@ -29,6 +29,7 @@ import com.example.tenet.ui.conversations.ConversationsScreen
 import com.example.tenet.ui.friends.FriendsScreen
 import com.example.tenet.ui.groups.GroupDetailScreen
 import com.example.tenet.ui.groups.GroupsScreen
+import com.example.tenet.ui.identities.IdentitiesScreen
 import com.example.tenet.ui.peers.PeersScreen
 import com.example.tenet.ui.peers.PeerDetailScreen
 import com.example.tenet.ui.postdetail.PostDetailScreen
@@ -231,6 +232,22 @@ fun TenetNavHost(
                     onShowQr = { peerId ->
                         navController.navigate("${Routes.QR_BASE}/${Uri.encode(peerId)}")
                     },
+                    onManageIdentities = {
+                        navController.navigate(Routes.IDENTITIES)
+                    },
+                )
+            }
+
+            // Identities management (full-screen, no bottom nav).
+            composable(Routes.IDENTITIES) {
+                IdentitiesScreen(
+                    onBack = { navController.popBackStack() },
+                    onSwitched = {
+                        navController.navigate(Routes.TIMELINE) {
+                            popUpTo(0) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    },
                 )
             }
 
@@ -326,4 +343,7 @@ object Routes {
     // Phase 4: QR code display
     const val QR_BASE = "qrcode"
     const val QR_CODE = "qrcode/{content}"
+
+    // Multiple identities management
+    const val IDENTITIES = "identities"
 }

--- a/android/app/app/src/main/java/com/example/tenet/ui/identities/IdentitiesScreen.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/identities/IdentitiesScreen.kt
@@ -1,0 +1,268 @@
+package com.example.tenet.ui.identities
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.tenet.uniffi.FfiIdentity
+
+/**
+ * Screen for listing, switching between, and creating identities.
+ *
+ * The active identity is highlighted with a filled check icon.  Tapping
+ * "Switch" on another identity recreates [TenetClient] under the hood and
+ * calls [onSwitched] so the caller can navigate back to the Timeline.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IdentitiesScreen(
+    onBack: () -> Unit = {},
+    onSwitched: () -> Unit = {},
+    viewModel: IdentitiesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Navigate to Timeline after a successful switch.
+    LaunchedEffect(state.switched) {
+        if (state.switched) onSwitched()
+    }
+
+    LaunchedEffect(state.error) {
+        state.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Identities") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = viewModel::showAddDialog) {
+                Icon(Icons.Default.Add, contentDescription = "Add identity")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+        ) {
+            when {
+                state.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+
+                state.identities.isEmpty() -> {
+                    Text(
+                        "No identities found. Tap + to create one.",
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(24.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                            horizontal = 16.dp,
+                            vertical = 8.dp,
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        items(state.identities, key = { it.shortId }) { identity ->
+                            IdentityCard(
+                                identity = identity,
+                                isSwitching = state.isSwitching,
+                                onSwitch = { viewModel.switchIdentity(identity) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // "Add Identity" dialog
+    if (state.showAddDialog) {
+        AlertDialog(
+            onDismissRequest = viewModel::dismissAddDialog,
+            title = { Text("New Identity") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        "A new keypair will be generated. Enter the relay URL for this identity.",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    OutlinedTextField(
+                        value = state.addRelayUrl,
+                        onValueChange = viewModel::onAddRelayUrlChange,
+                        label = { Text("Relay URL") },
+                        placeholder = { Text("http://relay.example.com:8080") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = viewModel::createIdentity,
+                    enabled = state.addRelayUrl.isNotBlank() && !state.isCreating,
+                ) {
+                    if (state.isCreating) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.height(18.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Text("Create")
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::dismissAddDialog) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun IdentityCard(
+    identity: FfiIdentity,
+    isSwitching: Boolean,
+    onSwitch: () -> Unit,
+) {
+    val containerColor = if (identity.isDefault) {
+        MaterialTheme.colorScheme.primaryContainer
+    } else {
+        MaterialTheme.colorScheme.surfaceVariant
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (identity.isDefault) {
+                        Icon(
+                            Icons.Default.CheckCircle,
+                            contentDescription = "Active",
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(Modifier.width(8.dp))
+                    }
+                    Text(
+                        text = if (identity.isDefault) "Active" else "Identity",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (identity.isDefault) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                }
+
+                if (!identity.isDefault) {
+                    OutlinedButton(
+                        onClick = onSwitch,
+                        enabled = !isSwitching,
+                    ) {
+                        if (isSwitching) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.height(16.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Text("Switch")
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = "ID: ${identity.shortId}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = identity.peerId.take(48) + if (identity.peerId.length > 48) "…" else "",
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+            )
+
+            identity.relayUrl?.let { relay ->
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "Relay: $relay",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/identities/IdentitiesViewModel.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/identities/IdentitiesViewModel.kt
@@ -1,0 +1,112 @@
+package com.example.tenet.ui.identities
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.tenet.data.TenetRepository
+import com.example.tenet.uniffi.FfiIdentity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class IdentitiesUiState(
+    val identities: List<FfiIdentity> = emptyList(),
+    val isLoading: Boolean = false,
+    val isSwitching: Boolean = false,
+    val error: String? = null,
+    /** True after a successful identity switch — the UI should navigate to Timeline. */
+    val switched: Boolean = false,
+    /** True while the "Add Identity" dialog is open. */
+    val showAddDialog: Boolean = false,
+    val addRelayUrl: String = "",
+    val isCreating: Boolean = false,
+)
+
+@HiltViewModel
+class IdentitiesViewModel @Inject constructor(
+    private val repository: TenetRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(IdentitiesUiState())
+    val uiState: StateFlow<IdentitiesUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
+            try {
+                val list = repository.listIdentities()
+                _uiState.value = _uiState.value.copy(identities = list, isLoading = false)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    error = e.message ?: "Failed to load identities",
+                )
+            }
+        }
+    }
+
+    fun switchIdentity(identity: FfiIdentity) {
+        if (identity.isDefault) return
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSwitching = true, error = null)
+            try {
+                repository.switchIdentity(identity)
+                _uiState.value = _uiState.value.copy(isSwitching = false, switched = true)
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isSwitching = false,
+                    error = e.message ?: "Failed to switch identity",
+                )
+            }
+        }
+    }
+
+    fun showAddDialog() {
+        val currentRelay = try { repository.relayUrl() } catch (_: Exception) { "" }
+        _uiState.value = _uiState.value.copy(
+            showAddDialog = true,
+            addRelayUrl = currentRelay,
+        )
+    }
+
+    fun dismissAddDialog() {
+        _uiState.value = _uiState.value.copy(showAddDialog = false, addRelayUrl = "")
+    }
+
+    fun onAddRelayUrlChange(url: String) {
+        _uiState.value = _uiState.value.copy(addRelayUrl = url)
+    }
+
+    fun createIdentity() {
+        val url = _uiState.value.addRelayUrl.trim()
+        if (url.isBlank()) return
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isCreating = true, error = null)
+            try {
+                repository.createIdentity(url)
+                val list = repository.listIdentities()
+                _uiState.value = _uiState.value.copy(
+                    identities = list,
+                    isCreating = false,
+                    showAddDialog = false,
+                    addRelayUrl = "",
+                )
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isCreating = false,
+                    error = e.message ?: "Failed to create identity",
+                )
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.value = _uiState.value.copy(error = null)
+    }
+}

--- a/android/app/app/src/main/java/com/example/tenet/ui/profile/ProfileScreen.kt
+++ b/android/app/app/src/main/java/com/example/tenet/ui/profile/ProfileScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.QrCode
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -52,6 +53,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 @Composable
 fun ProfileScreen(
     onShowQr: (peerId: String) -> Unit = {},
+    onManageIdentities: () -> Unit = {},
     viewModel: ProfileViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
@@ -81,6 +83,10 @@ fun ProfileScreen(
                         IconButton(onClick = { onShowQr(state.myPeerId) }) {
                             Icon(Icons.Default.QrCode, contentDescription = "Show QR code")
                         }
+                    }
+                    // Identity switcher
+                    IconButton(onClick = onManageIdentities) {
+                        Icon(Icons.Default.ManageAccounts, contentDescription = "Manage identities")
                     }
                     if (!state.isEditing && !state.isLoading) {
                         IconButton(onClick = {

--- a/android/tenet-ffi/src/tenet_ffi.udl
+++ b/android/tenet-ffi/src/tenet_ffi.udl
@@ -3,7 +3,23 @@
 // Phase 2: Conversations, replies, reactions, attachments, group messages
 // Phase 3: Peers detail, friends, groups, profiles, notifications
 
-namespace tenet_ffi {};
+namespace tenet_ffi {
+    // ---------------------------------------------------------------------------
+    // Identity management — namespace-level functions
+    // ---------------------------------------------------------------------------
+
+    /// List all identities available in data_dir.
+    [Throws=TenetError]
+    sequence<FfiIdentity> list_identities(string data_dir);
+
+    /// Create a new identity in data_dir and store relay_url as its relay.
+    [Throws=TenetError]
+    FfiIdentity create_identity(string data_dir, string relay_url);
+
+    /// Set the default identity for data_dir by its short_id.
+    [Throws=TenetError]
+    void set_default_identity(string data_dir, string short_id);
+};
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -138,14 +154,27 @@ dictionary FfiNotification {
     boolean is_read;
 };
 
+/// A local identity (one per directory under {data_dir}/identities/).
+dictionary FfiIdentity {
+    /// Short ID — first 12 chars of the peer ID, used as directory name.
+    string short_id;
+    /// Full peer ID (base64 public key).
+    string peer_id;
+    /// The relay URL stored for this identity, if any.
+    string? relay_url;
+    /// Whether this is the current default identity.
+    boolean is_default;
+};
+
 // ---------------------------------------------------------------------------
 // TenetClient interface
 // ---------------------------------------------------------------------------
 
 interface TenetClient {
     // Initialize (or load) an identity in data_dir and set the relay URL.
+    // identity_id selects a specific identity by short_id; null uses the default.
     [Throws=TenetError]
-    constructor(string data_dir, string relay_url);
+    constructor(string data_dir, string relay_url, string? identity_id);
 
     string my_peer_id();
     string relay_url();

--- a/android/tenet-ffi/src/types.rs
+++ b/android/tenet-ffi/src/types.rs
@@ -124,3 +124,19 @@ pub struct FfiNotification {
     pub created_at: i64,
     pub is_read: bool,
 }
+
+// ---------------------------------------------------------------------------
+// Multiple identities
+// ---------------------------------------------------------------------------
+
+/// A local identity entry as exposed across the FFI boundary.
+pub struct FfiIdentity {
+    /// Short ID used as the identity's directory name (first 12 chars of peer ID).
+    pub short_id: String,
+    /// Full peer ID (hex-encoded public key).
+    pub peer_id: String,
+    /// The relay URL stored for this identity, if any.
+    pub relay_url: Option<String>,
+    /// Whether this identity is the current default.
+    pub is_default: bool,
+}


### PR DESCRIPTION
Implements the multiple identities feature described in docs/clients/android.md.
Users can now create additional identities and switch between them from the Profile
screen via the new Identities management screen.

## Rust FFI layer (android/tenet-ffi/)

- `types.rs`: Add `FfiIdentity` struct (short_id, peer_id, relay_url, is_default).
- `lib.rs`:
  - `TenetClient::new` now accepts `identity_id: Option<String>` to select a
    specific identity by short ID; passing None uses the Rust-layer default.
  - Three new namespace-level free functions exposed to Kotlin:
    - `list_identities(data_dir)` — enumerate all identities, opening each
      identity's SQLite DB to read the peer ID and stored relay URL.
    - `create_identity(data_dir, relay_url)` — create a fresh keypair, store the
      relay URL, and return the new identity descriptor.
    - `set_default_identity(data_dir, short_id)` — write the new default into
      config.toml so subsequent no-arg resolutions pick the correct identity.
- `tenet_ffi.udl`:
  - Add `FfiIdentity` dictionary.
  - Add namespace functions: `list_identities`, `create_identity`,
    `set_default_identity`.
  - Update `TenetClient` constructor signature with the new `identity_id?` arg.

## Android Kotlin layer (android/app/)

- `TenetPreferences`: add `activeIdentityShortId: String?` (persisted in
  SharedPreferences under `active_identity_short_id`).
- `TenetRepository`:
  - `requireClient()` and `initialize()` pass `prefs.activeIdentityShortId` to
    the `TenetClient` constructor so the correct identity is loaded on startup.
  - New suspend functions: `listIdentities()`, `createIdentity(relayUrl)`,
    `switchIdentity(identity)`.  `switchIdentity` calls `ffiSetDefaultIdentity`,
    updates prefs, and atomically recreates `TenetClient` under the existing lock.
- `ui/identities/IdentitiesViewModel.kt`: new ViewModel with `load()`,
  `switchIdentity()`, `showAddDialog()`, `dismissAddDialog()`, and
  `createIdentity()` actions; emits `switched = true` after a successful switch
  so the screen navigates back to Timeline.
- `ui/identities/IdentitiesScreen.kt`: new screen listing all identities in
  cards (active identity highlighted in primary-container colour with a filled
  CheckCircle icon), "Switch" button on non-active identities, and a FAB that
  opens an "Add Identity" dialog asking for a relay URL.
- `TenetNavHost`: import `IdentitiesScreen`, add `Routes.IDENTITIES = "identities"`,
  add composable that navigates to Timeline (clearing the back stack) on switch.
- `ProfileScreen`: add `onManageIdentities` callback parameter and a
  `ManageAccounts` icon button in the TopAppBar that navigates to Identities.

https://claude.ai/code/session_01U2rK2Y8xz7UdQDT8Mnwbs6