### PR TITLE
Add QoS tier-based rate limiting and size-filtered inbox fetching

### DIFF
--- a/src/bin/debugger.rs
+++ b/src/bin/debugger.rs
@@ -179,6 +179,7 @@ fn start_in_process_relay(rt: &tokio::runtime::Runtime) -> Result<SocketAddr, Bo
             peer_log_interval: Duration::ZERO,
             log_sink: Some(Arc::new(|_| {})), // silence relay logs
             pause_flag: Arc::new(AtomicBool::new(false)),
+            qos: tenet::relay::RelayQosConfig::default(),
         };
         let state = RelayState::new(config);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use tenet::relay::{app, RelayConfig, RelayState};
+use tenet::relay::{app, RelayConfig, RelayQosConfig, RelayState, TierLimits};
 
 #[tokio::main]
 async fn main() {
@@ -22,6 +22,24 @@ async fn main() {
         peer_log_interval: Duration::from_secs(env_u64("TENET_RELAY_PEER_LOG_INTERVAL_SECS", 30)),
         log_sink: None,
         pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        qos: RelayQosConfig {
+            tier1: TierLimits {
+                max_envelopes: env_usize("TENET_QOS_TIER1_MAX_ENVELOPES", 20),
+                max_bytes: env_usize("TENET_QOS_TIER1_MAX_BYTES", 256 * 1024),
+            },
+            tier2: TierLimits {
+                max_envelopes: env_usize("TENET_QOS_TIER2_MAX_ENVELOPES", 100),
+                max_bytes: env_usize("TENET_QOS_TIER2_MAX_BYTES", 2 * 1024 * 1024),
+            },
+            tier3: TierLimits {
+                max_envelopes: env_usize("TENET_QOS_TIER3_MAX_ENVELOPES", 500),
+                max_bytes: env_usize("TENET_QOS_TIER3_MAX_BYTES", 10 * 1024 * 1024),
+            },
+            bidirectional_window: Duration::from_secs(env_u64(
+                "TENET_QOS_BIDIRECTIONAL_WINDOW_SECS",
+                7 * 24 * 3600,
+            )),
+        },
     };
 
     let state = RelayState::new(config);

--- a/src/simulation/config.rs
+++ b/src/simulation/config.rs
@@ -438,6 +438,7 @@ impl RelayConfigToml {
             peer_log_interval: Duration::from_secs(self.peer_log_interval_seconds.unwrap_or(30)),
             log_sink: None,
             pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            qos: crate::relay::RelayQosConfig::default(),
         }
     }
 }

--- a/tests/relay_tests.rs
+++ b/tests/relay_tests.rs
@@ -108,6 +108,7 @@ async fn relay_expires_messages_after_ttl() {
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
         pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        qos: tenet::relay::RelayQosConfig::default(),
     })
     .await;
 
@@ -169,6 +170,7 @@ async fn relay_deduplicates_by_message_id() {
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
         pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        qos: tenet::relay::RelayQosConfig::default(),
     })
     .await;
 
@@ -231,6 +233,7 @@ async fn node_can_send_and_receive_through_relay() {
         peer_log_interval: Duration::from_secs(30),
         log_sink: None,
         pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        qos: tenet::relay::RelayQosConfig::default(),
     })
     .await;
 
@@ -322,6 +325,7 @@ fn test_relay_config() -> RelayConfig {
         peer_log_interval: Duration::ZERO,
         log_sink: None,
         pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        qos: tenet::relay::RelayQosConfig::default(),
     }
 }
 

--- a/web/src/relay_dashboard.html
+++ b/web/src/relay_dashboard.html
@@ -42,6 +42,7 @@ tr:hover td{background:#fafafa}
 .badge{display:inline-block;padding:1px 7px;border-radius:10px;font-size:11px;background:#f0f4ff;color:#2563eb;font-weight:500}
 .empty{padding:24px;text-align:center;color:#bbb;font-size:13px}
 .footer{text-align:center;color:#bbb;font-size:12px;margin-top:16px;margin-bottom:32px}
+.sender-row{font-size:12px;line-height:1.6}
 @media(max-width:600px){.cards{grid-template-columns:repeat(2,1fr)}.lat-row{flex-wrap:wrap}}
 </style>
 </head>
@@ -118,15 +119,24 @@ async function refresh(){
   else{
     const maxB=Math.max(...inboxes.map(i=>i.queue_bytes),1);
     ib.innerHTML='<table><thead><tr>'+
-      '<th>Peer ID</th><th>Queue</th><th>Size</th><th>Last Seen</th><th>Delivered (1m / 1h / 24h)</th>'+
+      '<th>Peer ID</th><th>Queue</th><th>Size</th><th>Last Seen</th><th>Delivered (1m / 1h / 24h)</th><th>Top Senders</th>'+
       '</tr></thead><tbody>'+
-    inboxes.map(i=>'<tr>'+
-      '<td class="mono">'+fmtPeer(i.peer_id)+'</td>'+
-      '<td>'+i.queue_depth+'</td>'+
-      '<td>'+fmtBytes(i.queue_bytes)+'<span class="bar-wrap"><div class="bar-fill" style="width:'+Math.round(i.queue_bytes/maxB*100)+'%"></div></span></td>'+
-      '<td class="muted">'+fmtDur(i.last_seen_secs)+' ago</td>'+
-      '<td>'+rateCell(i.delivered_1m||0,i.delivered_1h||0,i.delivered_24h||0)+'</td>'+
-      '</tr>').join('')+'</tbody></table>'
+    inboxes.map(i=>{
+      const senders=i.senders||[];
+      const senderCell=senders.length===0?'<span class="muted">\u2014</span>':
+        senders.slice(0,3).map(s=>
+          '<div class="sender-row"><span class="mono">'+fmtPeer(s.sender_id)+'</span>'+
+          ' <span class="muted">('+s.count+' msg, '+fmtBytes(s.bytes)+')</span></div>'
+        ).join('')+(senders.length>3?'<div class="muted">+' +(senders.length-3)+' more</div>':'');
+      return '<tr>'+
+        '<td class="mono">'+fmtPeer(i.peer_id)+'</td>'+
+        '<td>'+i.queue_depth+'</td>'+
+        '<td>'+fmtBytes(i.queue_bytes)+'<span class="bar-wrap"><div class="bar-fill" style="width:'+Math.round(i.queue_bytes/maxB*100)+'%"></div></span></td>'+
+        '<td class="muted">'+fmtDur(i.last_seen_secs)+' ago</td>'+
+        '<td>'+rateCell(i.delivered_1m||0,i.delivered_1h||0,i.delivered_24h||0)+'</td>'+
+        '<td>'+senderCell+'</td>'+
+        '</tr>';
+    }).join('')+'</tbody></table>'
   }
 
   // Latency


### PR DESCRIPTION
## Summary

This PR implements a Quality of Service (QoS) system for the relay with three-tier rate limiting based on bidirectionality, plus support for size-filtered envelope fetching to improve client responsiveness.

## Key Changes

**QoS Rate Limiting:**
- Added `RelayQosConfig` with three tiers of per-sender-per-inbox quotas:
  - **Tier 1** (unknown): 20 envelopes, 256 KB (no prior contact)
  - **Tier 2** (acknowledged): 100 envelopes, 2 MB (recipient has replied before)
  - **Tier 3** (active): 500 envelopes, 10 MB (bidirectional traffic within window)
- Tracks bidirectionality state via `directed_last_seen` and `bidirectional_pairs` to automatically promote senders from Tier 1 → Tier 2 → Tier 3
- Implements fair eviction: when quota is exceeded, removes oldest message from the sender holding the most bytes in that inbox
- Returns `QuotaExceeded` (HTTP 429) when sender exceeds their tier's limits

**Size-Filtered Inbox Fetching:**
- Added `max_size_bytes` query parameter to `/inbox/{id}` and batch endpoints
- Allows clients to fetch only envelopes up to a size threshold, leaving oversized messages in the queue
- Enables two-pass sync: small envelopes (protocol/text) first for UI responsiveness, then large envelopes (attachments) in a second pass
- Web client now uses 8 KB threshold for initial sync, then fetches remaining messages

**Tracking & Accounting:**
- Added `sender_id` field to `StoredEnvelope` for QoS tracking
- Maintains `sender_inbox_usage` map tracking envelope count and bytes per (sender, recipient) pair
- Updated `prune_expired()` and eviction logic to properly decrement usage counters
- Dashboard now displays per-sender usage breakdown for each inbox, sorted by bytes descending

**Configuration:**
- QoS limits are configurable via environment variables (`TENET_QOS_TIER*_*`)
- Bidirectional activity window defaults to 7 days, also configurable
- Debug stats endpoint exposes QoS configuration and per-sender inbox details

## Implementation Details

- Broadcasts bypass per-sender QoS (recipient is "*", not a specific peer)
- Tier assignment uses canonical (lexicographic-min) peer ordering for bidirectionality detection
- Size filtering uses index-based removal to avoid shifting overhead when skipping oversized envelopes
- Usage decrements are collected during queue operations and applied in batch to avoid repeated map lookups

https://claude.ai/code/session_01C9pLy5YREYumReAqravxhi