### PR TITLE
Migrate peer and message storage from JSON files to SQLite

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -122,16 +122,14 @@ Sources: code `// TODO` comments, `docs/relay_qos.md`, `docs/public_payload_fix.
 
 ## CLI (`tenet` binary)
 
-- [ ] **Peer registry not shared with web client** — the CLI stores peers in `peers.json`; the
-  web client uses the SQLite `peers` table. Adding a peer in the CLI does not make them visible
-  in the web UI and vice versa. Full fix would have both clients read/write the same SQLite table.
-  Medium-term workaround: add a `--db` flag to the CLI to target the web client's `tenet.db`.
-- [ ] **Limited to Direct messages** — the CLI has no commands for public posts, friend requests,
-  group messaging, reactions, or profiles. These require `tenet-web`. If the CLI is to be a
-  standalone tool, it needs at minimum `receive-all` (public + direct) and `post` commands.
-- [ ] **JSONL message storage** — received messages are appended to `inbox.jsonl` rather than the
-  structured SQLite `messages` table. This prevents the CLI and web client from sharing message
-  history. Migrating CLI receive to use SQLite would unify history across clients.
+- [x] **Peer registry not shared with web client** — CLI now uses the same `resolve_identity()`
+  system as the web client; `add-peer` writes to the identity's SQLite `peers` table and all
+  commands read peers from SQLite. Both clients share the same database.
+- [x] **Limited to Direct messages** — added `post <message> [--relay <url>]` for public posts
+  and `receive-all [--relay <url>]` to sync all message kinds (direct, public, group).
+- [x] **JSONL message storage** — received messages are stored via `store_received_envelope` into
+  the SQLite `messages` table; sent envelopes go into the SQLite `outbox` table. The CLI and web
+  client now share the same message history.
 
 ---
 


### PR DESCRIPTION
## Summary
This PR refactors the tenet-crypto CLI to use SQLite database storage for peers and messages instead of JSON files. The changes modernize the data persistence layer while adding support for new message types (public messages and group messages).

## Key Changes

- **Storage Migration**: Replaced JSON-based peer and message storage (`peers.json`, `outbox.jsonl`, `inbox.jsonl`) with SQLite tables (`PeerRow`, `OutboxRow`, and received envelope storage)
- **New Commands**: Added `post` command for sending public messages and `receive-all` command for receiving all message types (direct, public, and group)
- **Peer Registry Population**: Introduced `populate_peer_registry()` helper to load peers from SQLite into the relay client for signature verification
- **Message Type Support**: Updated sync logic to filter and handle different message kinds (`MessageKind::Direct`, `MessageKind::Public`, `MessageKind::FriendGroup`)
- **Improved Peer Management**: `add_peer()` now stores peer data with additional metadata (timestamps, online status, blocking/muting flags) in the SQLite schema
- **Refactored Argument Parsing**: Converted if-else chains to match expressions for cleaner code
- **Updated Imports**: Removed `serde` serialization for local JSON files and added `SystemTime` for timestamp generation; imported new types from `tenet::protocol` and `tenet::storage`

## Implementation Details

- Peers are now stored with encryption keys and signing keys separately, allowing signature verification to be skipped when only encryption keys are available
- Message timestamps are generated using `SystemTime::now()` for consistency
- The `resolve_and_log()` function now returns a `Storage` instance instead of a directory path, centralizing database access
- Removed helper functions for JSON file path management (`peers_path()`, `outbox_path()`, `inbox_path()`, `load_peers()`, `save_peers()`, `append_json_line()`)
- Both `sync` and `receive-all` commands populate the peer registry before syncing to ensure proper message verification

https://claude.ai/code/session_01W8K6bGcxrXKG8zaZzZHK8i