### PR TITLE
Implement mesh catch-up protocol in simulation client

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -137,26 +137,24 @@ Sources: code `// TODO` comments, `docs/relay_qos.md`, `docs/public_payload_fix.
 
 ### Mesh protocol in simulation
 
-- [ ] **Simulation client mesh catch-up** — `src/client.rs` has a separate gossip path
-  (`handle_message_request`, `forward_public_message_to_peers`). The four-phase mesh protocol
-  (MeshAvailable / MeshRequest / MeshDelivery) implemented in `message_handler.rs` for the web
-  client is not wired into the simulation client. Without this, multi-peer catch-up scenarios
-  cannot be tested in simulation. (`docs/public_mesh_plan.md` — "not done, tracked as future
-  work")
+- [x] **Simulation client mesh catch-up** — `SimulationClient.handle_inbox` now handles
+  `MessageRequest` / `MeshAvailable` / `MeshRequest` / `MeshDelivery` directly via the new
+  `handle_mesh_meta()` method when no external `MessageHandler` is registered. The simulation
+  harness already routes outgoing envelopes through the relay, so all four phases are exercised
+  end-to-end in simulation scenarios.
 
 ### Debugger REPL mesh queries
 
-- [ ] **Wire mesh queries into `tenet-debugger`** — the REPL uses the simulation harness, not
-  the web client stack. Mesh queries (`MessageRequest` → `MeshAvailable` → `MeshRequest` →
-  `MeshDelivery`) are not invocable from the debugger. A `mesh-query <peer-a> <peer-b>` command
-  would let developers test catch-up interactively. (`docs/public_mesh_plan.md` — "not done,
-  tracked as future work")
+- [x] **Wire mesh queries into `tenet-debugger`** — added `mesh-query <peer-a> <peer-b>` REPL
+  command. The command posts a `MessageRequest` from peer-a to peer-b then drives five sync
+  rounds to complete the full four-phase exchange, printing each step's outcome.
 
 ### Doc comment updates
 
-- [ ] **Update `CLAUDE.md` and `Client` trait doc comments** for the mesh protocol `MetaMessage`
-  variants (`MeshAvailable`, `MeshRequest`, `MeshDelivery`) and when `on_meta` is called for
-  them. (`docs/public_mesh_plan.md` — "update when API stabilises")
+- [x] **Update `CLAUDE.md` and `Client` trait doc comments** — `CLAUDE.md` now contains a
+  "Public-Message Mesh Catch-up Protocol" section with a phase table, implementation notes, and
+  pointers to each implementation. `MessageHandler.on_meta` doc comment lists all four mesh
+  variants and their expected response envelopes.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the four-phase public-message mesh catch-up protocol in `SimulationClient`, enabling offline peers to recover missed messages through a pull-based exchange. Also adds interactive mesh-query support to the debugger REPL and updates documentation.

## Key Changes

- **Simulation mesh protocol** (`src/client.rs`):
  - Added three constants for simulation limits: `MAX_SIM_MESH_IDS` (500), `MAX_SIM_MESH_REQUEST_IDS` (100), `MAX_SIM_MESH_BATCH` (10)
  - Implemented `handle_mesh_meta()` method to handle all four phases of the mesh protocol:
    - Phase 1 (responder): `MessageRequest` → respond with `MeshAvailable` listing public message IDs
    - Phase 2 (requester): `MeshAvailable` → respond with `MeshRequest` for unknown IDs
    - Phase 3 (responder): `MeshRequest` → respond with batched `MeshDelivery` envelopes plus sender keys
    - Phase 4 (requester): `MeshDelivery` → store delivered public messages in cache
  - Wired `handle_mesh_meta()` into `handle_inbox()` when no external `MessageHandler` is registered
  - Enhanced `MessageHandler.on_meta()` doc comment with detailed phase descriptions and return conventions

- **Debugger mesh queries** (`src/bin/debugger.rs`):
  - Added `mesh-query <peer-a> <peer-b>` REPL command
  - Implemented `mesh_query()` function that drives the complete four-phase exchange interactively:
    - Phase 1: peer-a posts `MessageRequest` to peer-b
    - Phases 2–5: alternating syncs of peer-b and peer-a to complete the round-trip
    - Prints status at each step for visibility into the protocol flow

- **Documentation** (`CLAUDE.md`):
  - Added "Public-Message Mesh Catch-up Protocol" section with phase table
  - Documented expected behavior for each `MetaMessage` variant
  - Listed implementation locations: `StorageMessageHandler`, `SimulationClient`, and debugger command

- **TODO tracking** (`docs/todo.md`):
  - Marked "Simulation client mesh catch-up" as complete
  - Marked "Debugger REPL mesh queries" as complete
  - Marked "Doc comment updates" as complete

## Implementation Details

- The simulation client's `handle_mesh_meta()` reuses existing infrastructure (`public_message_cache`, `public_message_metadata`, `seen` set) to track and deliver messages
- Batching in Phase 3 responder ensures large message sets are split across multiple `MeshDelivery` envelopes (max 10 per envelope)
- The debugger command validates both peers are online before initiating the query
- All four phases are now exercised end-to-end in simulation scenarios since the harness already routes outgoing envelopes through the relay

https://claude.ai/code/session_0138RMYgkgoDiKNJtQF76vta