### PR TITLE
Implement Attachment v2 Option D: Tiered Blob Protocol (Phase 1)

### DIFF
--- a/src/bin/debugger.rs
+++ b/src/bin/debugger.rs
@@ -182,6 +182,7 @@ fn start_in_process_relay(rt: &tokio::runtime::Runtime) -> Result<SocketAddr, Bo
             qos: tenet::relay::RelayQosConfig::default(),
             blob_max_chunk_bytes: 512 * 1024,
             blob_daily_quota_bytes: 500 * 1024 * 1024,
+            blob_ttl: Duration::from_secs(30 * 24 * 3600),
         };
         let state = RelayState::new(config);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/src/bin/debugger.rs
+++ b/src/bin/debugger.rs
@@ -180,6 +180,8 @@ fn start_in_process_relay(rt: &tokio::runtime::Runtime) -> Result<SocketAddr, Bo
             log_sink: Some(Arc::new(|_| {})), // silence relay logs
             pause_flag: Arc::new(AtomicBool::new(false)),
             qos: tenet::relay::RelayQosConfig::default(),
+            blob_max_chunk_bytes: 512 * 1024,
+            blob_daily_quota_bytes: 500 * 1024 * 1024,
         };
         let state = RelayState::new(config);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -42,6 +42,7 @@ async fn main() {
         },
         blob_max_chunk_bytes: env_usize("TENET_BLOB_MAX_CHUNK_BYTES", 512 * 1024),
         blob_daily_quota_bytes: env_u64("TENET_BLOB_DAILY_QUOTA_BYTES", 500 * 1024 * 1024),
+        blob_ttl: Duration::from_secs(env_u64("TENET_BLOB_TTL_SECS", 30 * 24 * 3600)),
     };
 
     let state = RelayState::new(config);

--- a/src/bin/relay.rs
+++ b/src/bin/relay.rs
@@ -40,6 +40,8 @@ async fn main() {
                 7 * 24 * 3600,
             )),
         },
+        blob_max_chunk_bytes: env_usize("TENET_BLOB_MAX_CHUNK_BYTES", 512 * 1024),
+        blob_daily_quota_bytes: env_u64("TENET_BLOB_DAILY_QUOTA_BYTES", 500 * 1024 * 1024),
     };
 
     let state = RelayState::new(config);

--- a/src/simulation/config.rs
+++ b/src/simulation/config.rs
@@ -439,6 +439,8 @@ impl RelayConfigToml {
             log_sink: None,
             pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             qos: crate::relay::RelayQosConfig::default(),
+            blob_max_chunk_bytes: 512 * 1024,
+            blob_daily_quota_bytes: 500 * 1024 * 1024,
         }
     }
 }

--- a/src/simulation/config.rs
+++ b/src/simulation/config.rs
@@ -441,6 +441,7 @@ impl RelayConfigToml {
             qos: crate::relay::RelayQosConfig::default(),
             blob_max_chunk_bytes: 512 * 1024,
             blob_daily_quota_bytes: 500 * 1024 * 1024,
+            blob_ttl: Duration::from_secs(30 * 24 * 3600),
         }
     }
 }

--- a/src/web_client/config.rs
+++ b/src/web_client/config.rs
@@ -15,7 +15,17 @@ pub(crate) const WEB_HPKE_INFO: &[u8] = b"tenet-web";
 pub(crate) const WEB_PAYLOAD_AAD: &[u8] = b"tenet-web";
 pub(crate) const WS_CHANNEL_CAPACITY: usize = 256;
 pub(crate) const MAX_WS_CONNECTIONS: usize = 8;
-pub(crate) const MAX_ATTACHMENT_SIZE: u64 = 10 * 1024 * 1024; // 10 MB per attachment
+/// Files smaller than this threshold are inlined inside the HPKE-encrypted
+/// envelope payload (v1 / `Inline` tier).  Files at or above this size are
+/// split into chunks and uploaded to the relay blob endpoint (`RelayBlob` tier).
+pub(crate) const INLINE_THRESHOLD: u64 = 256 * 1024; // 256 KiB
+
+/// Target size (bytes) of each plaintext chunk for the `RelayBlob` tier.
+pub(crate) const CHUNK_SIZE: usize = 256 * 1024; // 256 KiB plaintext per chunk
+
+/// Maximum total attachment size accepted by `POST /api/attachments`.
+/// Raised to accommodate `RelayBlob` tier uploads.
+pub(crate) const MAX_ATTACHMENT_SIZE: u64 = 50 * 1024 * 1024; // 50 MiB
 
 /// Web server for the Tenet peer-to-peer social network.
 ///

--- a/src/web_client/handlers/attachments.rs
+++ b/src/web_client/handlers/attachments.rs
@@ -5,12 +5,77 @@ use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum_extra::extract::Multipart;
 use base64::Engine as _;
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
+use rand::RngCore;
 use sha2::{Digest, Sha256};
 
-use crate::storage::AttachmentRow;
-use crate::web_client::config::MAX_ATTACHMENT_SIZE;
+use crate::storage::{AttachmentRow, BlobManifestRow};
+use crate::web_client::config::{CHUNK_SIZE, INLINE_THRESHOLD, MAX_ATTACHMENT_SIZE};
 use crate::web_client::state::SharedState;
 use crate::web_client::utils::{api_error, now_secs};
+
+/// Derive a deterministic per-chunk nonce from the blob key and chunk index.
+///
+/// `nonce = SHA-256(blob_key || chunk_index_le64)[:12]`
+///
+/// This avoids storing a nonce per chunk while preventing nonce reuse across
+/// chunks of the same blob.
+fn derive_chunk_nonce(blob_key: &[u8; 32], chunk_index: u64) -> [u8; 12] {
+    let mut hasher = Sha256::new();
+    hasher.update(blob_key);
+    hasher.update(chunk_index.to_le_bytes());
+    let digest = hasher.finalize();
+    let mut nonce = [0u8; 12];
+    nonce.copy_from_slice(&digest[..12]);
+    nonce
+}
+
+/// Encrypt a single chunk with the blob key and a per-chunk nonce.
+///
+/// Returns `(encrypted_bytes, sha256_hex_of_encrypted_bytes)`.
+fn encrypt_chunk(
+    cipher: &ChaCha20Poly1305,
+    blob_key: &[u8; 32],
+    chunk_index: u64,
+    chunk: &[u8],
+) -> Result<(Vec<u8>, String), String> {
+    let nonce_bytes = derive_chunk_nonce(blob_key, chunk_index);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let encrypted = cipher
+        .encrypt(nonce, chunk)
+        .map_err(|e| format!("encryption failed: {e}"))?;
+    let hash = hex::encode(Sha256::digest(&encrypted));
+    Ok((encrypted, hash))
+}
+
+/// Upload a chunk to the relay blob endpoint.
+///
+/// Returns the chunk hash on success, or an error string on failure.
+fn upload_chunk_to_relay(
+    relay_url: &str,
+    chunk_hash: &str,
+    encrypted: &[u8],
+    sender_id: Option<&str>,
+) -> Result<(), String> {
+    let data_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(encrypted);
+    let mut body = serde_json::json!({
+        "chunk_hash": chunk_hash,
+        "data_b64": data_b64,
+    });
+    if let Some(sid) = sender_id {
+        body["sender_id"] = serde_json::Value::String(sid.to_string());
+    }
+    let url = format!("{}/blobs", relay_url.trim_end_matches('/'));
+    let resp = ureq::post(&url)
+        .set("Content-Type", "application/json")
+        .send_string(&body.to_string())
+        .map_err(|e| format!("relay upload failed: {e}"))?;
+    match resp.status() {
+        201 | 409 => Ok(()), // 409 = already exists, that's fine (idempotent)
+        s => Err(format!("relay returned unexpected status {s}")),
+    }
+}
 
 pub async fn upload_attachment_handler(
     State(state): State<SharedState>,
@@ -55,33 +120,152 @@ pub async fn upload_attachment_handler(
 
     let mime = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
 
-    // Compute content hash (SHA256, base64 URL-safe)
+    // Compute content hash of the **plaintext** file (SHA-256, base64 URL-safe no-pad).
     let digest = Sha256::digest(&data);
     let content_hash = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
 
     let now = now_secs();
     let size = data.len() as u64;
 
-    let st = state.lock().await;
-    let row = AttachmentRow {
-        content_hash: content_hash.clone(),
-        content_type: mime.clone(),
-        size_bytes: size,
-        data,
-        created_at: now,
-    };
+    // Determine transport tier based on file size.
+    if size < INLINE_THRESHOLD {
+        // --- Inline tier (v1 behaviour) ---
+        let st = state.lock().await;
+        let row = AttachmentRow {
+            content_hash: content_hash.clone(),
+            content_type: mime.clone(),
+            size_bytes: size,
+            data,
+            created_at: now,
+        };
+        if let Err(e) = st.storage.insert_attachment(&row) {
+            return api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string());
+        }
+        let json = serde_json::json!({
+            "content_hash": content_hash,
+            "content_type": mime,
+            "size_bytes": size,
+            "filename": filename,
+            "transport": "inline",
+        });
+        (StatusCode::CREATED, axum::Json(json)).into_response()
+    } else {
+        // --- RelayBlob tier ---
+        // Require a configured relay URL.
+        let relay_url = {
+            let st = state.lock().await;
+            match st.relay_url.clone() {
+                Some(u) => u,
+                None => {
+                    return api_error(
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "no relay configured; cannot upload blob",
+                    )
+                }
+            }
+        };
 
-    if let Err(e) = st.storage.insert_attachment(&row) {
-        return api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string());
+        // Generate a random 32-byte blob key.
+        let mut blob_key_bytes = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut blob_key_bytes);
+        let cipher = ChaCha20Poly1305::new(Key::from_slice(&blob_key_bytes));
+
+        // Split plaintext into CHUNK_SIZE chunks, encrypt each, upload to relay.
+        let chunks: Vec<&[u8]> = data.chunks(CHUNK_SIZE).collect();
+        let mut chunk_hashes: Vec<String> = Vec::with_capacity(chunks.len());
+
+        // Collect sender_id for quota tracking (read from state before spawning blocking tasks).
+        let sender_id = {
+            let st = state.lock().await;
+            Some(st.keypair.id.clone())
+        };
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            let (encrypted, chunk_hash) =
+                match encrypt_chunk(&cipher, &blob_key_bytes, i as u64, chunk) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        return api_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("chunk encryption failed: {e}"),
+                        )
+                    }
+                };
+
+            let relay_url_c = relay_url.clone();
+            let chunk_hash_c = chunk_hash.clone();
+            let sender_id_c = sender_id.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                upload_chunk_to_relay(
+                    &relay_url_c,
+                    &chunk_hash_c,
+                    &encrypted,
+                    sender_id_c.as_deref(),
+                )
+            })
+            .await;
+
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    return api_error(
+                        StatusCode::BAD_GATEWAY,
+                        format!("relay chunk upload failed: {e}"),
+                    )
+                }
+                Err(e) => {
+                    return api_error(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("internal error: {e}"),
+                    )
+                }
+            }
+
+            chunk_hashes.push(chunk_hash);
+        }
+
+        let blob_key_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(blob_key_bytes);
+
+        // Persist the blob manifest and metadata (no inline data for relay blobs).
+        let st = state.lock().await;
+
+        // Insert a lightweight metadata row into `attachments` (no inline data).
+        let row = AttachmentRow {
+            content_hash: content_hash.clone(),
+            content_type: mime.clone(),
+            size_bytes: size,
+            data: Vec::new(), // relay blobs have no local inline data
+            created_at: now,
+        };
+        if let Err(e) = st.storage.insert_attachment(&row) {
+            return api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string());
+        }
+
+        // Persist the blob manifest so `build_attachment_refs` can later
+        // reconstruct the `AttachmentTransport::RelayBlob` field.
+        let manifest = BlobManifestRow {
+            content_hash: content_hash.clone(),
+            blob_key: blob_key_b64.clone(),
+            relay_url: relay_url.clone(),
+            chunk_hashes: chunk_hashes.clone(),
+            total_size: size,
+            created_at: now,
+        };
+        if let Err(e) = st.storage.insert_blob_manifest(&manifest) {
+            return api_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string());
+        }
+
+        let json = serde_json::json!({
+            "content_hash": content_hash,
+            "content_type": mime,
+            "size_bytes": size,
+            "filename": filename,
+            "transport": "relay_blob",
+            "relay_url": relay_url,
+            "chunk_count": chunk_hashes.len(),
+        });
+        (StatusCode::CREATED, axum::Json(json)).into_response()
     }
-
-    let json = serde_json::json!({
-        "content_hash": content_hash,
-        "content_type": mime,
-        "size_bytes": size,
-        "filename": filename,
-    });
-    (StatusCode::CREATED, axum::Json(json)).into_response()
 }
 
 pub async fn download_attachment_handler(

--- a/tests/attachment_v2_tests.rs
+++ b/tests/attachment_v2_tests.rs
@@ -1,0 +1,425 @@
+//! Integration tests for the Attachment v2 Option D blob endpoints.
+//!
+//! Tests cover:
+//! - Upload a chunk (`POST /blobs`)
+//! - Download a chunk (`GET /blobs/:hash`)
+//! - Conflict on duplicate upload
+//! - Integrity rejection (mismatched hash)
+//! - Chunk-size quota enforcement
+//! - Delete a chunk (`DELETE /blobs/:hash`)
+//! - `AttachmentTransport` serialisation round-trip
+
+use std::io::Read;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
+use tokio::sync::oneshot;
+
+use tenet::protocol::{AttachmentRef, AttachmentTransport, ContentId};
+use tenet::relay::{app, RelayConfig, RelayQosConfig, RelayState};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_config(blob_max_chunk_bytes: usize, blob_daily_quota_bytes: u64) -> RelayConfig {
+    RelayConfig {
+        ttl: Duration::from_secs(3600),
+        max_messages: 100,
+        max_bytes: 10 * 1024 * 1024,
+        retry_backoff: Vec::new(),
+        peer_log_window: Duration::from_secs(60),
+        peer_log_interval: Duration::ZERO,
+        log_sink: Some(Arc::new(|_| {})),
+        pause_flag: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        qos: RelayQosConfig::default(),
+        blob_max_chunk_bytes,
+        blob_daily_quota_bytes,
+    }
+}
+
+async fn start_relay(config: RelayConfig) -> (String, oneshot::Sender<()>) {
+    let state = RelayState::new(config);
+    let router: Router = app(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind relay");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            router.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(async {
+            let _ = shutdown_rx.await;
+        })
+        .await
+        .ok();
+    });
+    (format!("http://{addr}"), shutdown_tx)
+}
+
+/// Prepare a minimal valid upload body: encrypt some plaintext, compute hash.
+///
+/// Returns `(chunk_hash_hex, data_b64, raw_encrypted_bytes)`.
+fn make_chunk(plaintext: &[u8]) -> (String, String, Vec<u8>) {
+    // For tests we treat the plaintext as "already encrypted" (no actual AEAD).
+    // What matters is that hash(raw) == declared chunk_hash.
+    let raw = plaintext.to_vec();
+    let hash = hex::encode(Sha256::digest(&raw));
+    let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&raw);
+    (hash, b64, raw)
+}
+
+fn post_blob(base_url: &str, chunk_hash: &str, data_b64: &str, sender_id: Option<&str>) -> u16 {
+    let mut body = serde_json::json!({
+        "chunk_hash": chunk_hash,
+        "data_b64": data_b64,
+    });
+    if let Some(sid) = sender_id {
+        body["sender_id"] = serde_json::Value::String(sid.to_string());
+    }
+    let url = format!("{base_url}/blobs");
+    match ureq::post(&url)
+        .set("Content-Type", "application/json")
+        .send_string(&body.to_string())
+    {
+        Ok(r) => r.status(),
+        Err(ureq::Error::Status(code, _)) => code,
+        Err(e) => panic!("request failed: {e}"),
+    }
+}
+
+fn get_blob(base_url: &str, chunk_hash: &str) -> (u16, Vec<u8>) {
+    let url = format!("{base_url}/blobs/{chunk_hash}");
+    match ureq::get(&url).call() {
+        Ok(r) => {
+            let status = r.status();
+            let mut buf = Vec::new();
+            r.into_reader().read_to_end(&mut buf).unwrap_or(0);
+            (status, buf)
+        }
+        Err(ureq::Error::Status(code, r)) => {
+            let mut buf = Vec::new();
+            r.into_reader().read_to_end(&mut buf).unwrap_or(0);
+            (code, buf)
+        }
+        Err(e) => panic!("request failed: {e}"),
+    }
+}
+
+fn delete_blob(base_url: &str, chunk_hash: &str) -> u16 {
+    let url = format!("{base_url}/blobs/{chunk_hash}");
+    match ureq::delete(&url).call() {
+        Ok(r) => r.status(),
+        Err(ureq::Error::Status(code, _)) => code,
+        Err(e) => panic!("request failed: {e}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn blob_upload_and_download_roundtrip() {
+    let (base_url, shutdown_tx) = start_relay(make_config(512 * 1024, 500 * 1024 * 1024)).await;
+
+    let plaintext = b"hello relay blob world!";
+    let (hash, b64, raw) = make_chunk(plaintext);
+
+    // Upload
+    let status = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        let hash = hash.clone();
+        let b64 = b64.clone();
+        move || post_blob(&base_url, &hash, &b64, None)
+    })
+    .await
+    .unwrap();
+    assert_eq!(status, 201, "expected 201 Created");
+
+    // Download
+    let (dl_status, dl_data) = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        let hash = hash.clone();
+        move || get_blob(&base_url, &hash)
+    })
+    .await
+    .unwrap();
+    assert_eq!(dl_status, 200, "expected 200 OK");
+    assert_eq!(dl_data, raw, "downloaded data should match uploaded data");
+
+    shutdown_tx.send(()).ok();
+}
+
+#[tokio::test]
+async fn blob_upload_conflict_returns_409() {
+    let (base_url, shutdown_tx) = start_relay(make_config(512 * 1024, 500 * 1024 * 1024)).await;
+
+    let (hash, b64, _) = make_chunk(b"duplicate chunk");
+
+    let upload = {
+        let base_url = base_url.clone();
+        let hash = hash.clone();
+        let b64 = b64.clone();
+        move || post_blob(&base_url, &hash, &b64, None)
+    };
+
+    let s1 = tokio::task::spawn_blocking(upload.clone()).await.unwrap();
+    assert_eq!(s1, 201, "first upload should succeed");
+
+    let s2 = tokio::task::spawn_blocking(upload).await.unwrap();
+    assert_eq!(s2, 409, "second upload should return 409 Conflict");
+
+    shutdown_tx.send(()).ok();
+}
+
+#[tokio::test]
+async fn blob_mismatched_hash_rejected() {
+    let (base_url, shutdown_tx) = start_relay(make_config(512 * 1024, 500 * 1024 * 1024)).await;
+
+    let (_, b64, _) = make_chunk(b"some data");
+    // Deliberate wrong hash (all zeros).
+    let wrong_hash = "0".repeat(64);
+
+    let status = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        move || post_blob(&base_url, &wrong_hash, &b64, None)
+    })
+    .await
+    .unwrap();
+    assert_eq!(status, 400, "mismatched hash should return 400");
+
+    shutdown_tx.send(()).ok();
+}
+
+#[tokio::test]
+async fn blob_invalid_hash_format_rejected() {
+    let (base_url, shutdown_tx) = start_relay(make_config(512 * 1024, 500 * 1024 * 1024)).await;
+
+    let (_, b64, _) = make_chunk(b"data");
+    let bad_hash = "not-a-hex-hash";
+
+    let status = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        move || post_blob(&base_url, bad_hash, &b64, None)
+    })
+    .await
+    .unwrap();
+    assert_eq!(status, 400, "invalid hash format should return 400");
+
+    shutdown_tx.send(()).ok();
+}
+
+#[tokio::test]
+async fn blob_download_not_found_returns_404() {
+    let (base_url, shutdown_tx) = start_relay(make_config(512 * 1024, 500 * 1024 * 1024)).await;
+
+    let missing_hash = "a".repeat(64);
+    let (status, _) = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        move || get_blob(&base_url, &missing_hash)
+    })
+    .await
+    .unwrap();
+    assert_eq!(status, 404, "missing chunk should return 404");
+
+    shutdown_tx.send(()).ok();
+}
+
+#[tokio::test]
+async fn blob_exceeds_max_chunk_size_rejected() {
+    // Set a tiny max chunk size of 4 bytes.
+    let (base_url, shutdown_tx) = start_relay(make_config(4, 500 * 1024 * 1024)).await;
+
+    let (hash, b64, _) = make_chunk(b"this is longer than 4 bytes");
+
+    let status = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        move || post_blob(&base_url, &hash, &b64, None)
+    })
+    .await
+    .unwrap();
+    assert_eq!(status, 413, "oversized chunk should return 413");
+
+    shutdown_tx.send(()).ok();
+}
+
+#[tokio::test]
+async fn blob_daily_quota_exceeded_returns_429() {
+    // Allow only 10 bytes per day.
+    let (base_url, shutdown_tx) = start_relay(make_config(512 * 1024, 10)).await;
+
+    // First chunk: 5 bytes — fits within quota.
+    let (hash1, b64_1, _) = make_chunk(b"hello");
+    let s1 = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        let hash1 = hash1.clone();
+        move || post_blob(&base_url, &hash1, &b64_1, Some("sender-abc"))
+    })
+    .await
+    .unwrap();
+    assert_eq!(s1, 201, "first chunk should fit in quota");
+
+    // Second chunk: 10 bytes — would push total past the 10-byte limit.
+    let (hash2, b64_2, _) = make_chunk(b"0123456789");
+    let s2 = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        move || post_blob(&base_url, &hash2, &b64_2, Some("sender-abc"))
+    })
+    .await
+    .unwrap();
+    assert_eq!(s2, 429, "second chunk should exceed daily quota");
+
+    shutdown_tx.send(()).ok();
+}
+
+#[tokio::test]
+async fn blob_delete_removes_chunk() {
+    let (base_url, shutdown_tx) = start_relay(make_config(512 * 1024, 500 * 1024 * 1024)).await;
+
+    let (hash, b64, _) = make_chunk(b"delete me");
+
+    // Upload
+    tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        let hash = hash.clone();
+        let b64 = b64.clone();
+        move || post_blob(&base_url, &hash, &b64, None)
+    })
+    .await
+    .unwrap();
+
+    // Delete
+    let del_status = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        let hash = hash.clone();
+        move || delete_blob(&base_url, &hash)
+    })
+    .await
+    .unwrap();
+    assert_eq!(del_status, 204, "delete should return 204 No Content");
+
+    // Confirm gone
+    let (get_status, _) = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        let hash = hash.clone();
+        move || get_blob(&base_url, &hash)
+    })
+    .await
+    .unwrap();
+    assert_eq!(get_status, 404, "deleted chunk should return 404");
+
+    shutdown_tx.send(()).ok();
+}
+
+#[tokio::test]
+async fn blob_delete_not_found_returns_404() {
+    let (base_url, shutdown_tx) = start_relay(make_config(512 * 1024, 500 * 1024 * 1024)).await;
+
+    let missing = "b".repeat(64);
+    let status = tokio::task::spawn_blocking({
+        let base_url = base_url.clone();
+        move || delete_blob(&base_url, &missing)
+    })
+    .await
+    .unwrap();
+    assert_eq!(status, 404, "deleting missing chunk should return 404");
+
+    shutdown_tx.send(()).ok();
+}
+
+// ---------------------------------------------------------------------------
+// Protocol serialisation round-trip tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn attachment_transport_inline_roundtrip() {
+    let att = AttachmentRef {
+        content_id: ContentId::from_bytes(b"test"),
+        content_type: "image/png".to_string(),
+        size: 42,
+        filename: None,
+        data: Some("aGVsbG8=".to_string()),
+        transport: None, // None == Inline
+    };
+    let json = serde_json::to_string(&att).unwrap();
+    let roundtrip: AttachmentRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(att, roundtrip);
+    // transport field should be absent in JSON (skip_serializing_if = None).
+    assert!(
+        !json.contains("transport"),
+        "transport should be absent for inline"
+    );
+}
+
+#[test]
+fn attachment_transport_relay_blob_roundtrip() {
+    let att = AttachmentRef {
+        content_id: ContentId::from_bytes(b"test"),
+        content_type: "video/mp4".to_string(),
+        size: 10_000_000,
+        filename: Some("movie.mp4".to_string()),
+        data: None,
+        transport: Some(AttachmentTransport::RelayBlob {
+            relay_url: "https://relay.example.com".to_string(),
+            chunk_hashes: vec!["abc123".repeat(10), "def456".repeat(10)],
+            blob_key: "c29tZWtleWJ5dGVzMTIzNDU2Nzg5MGFiY2Q".to_string(),
+        }),
+    };
+    let json = serde_json::to_string(&att).unwrap();
+    let roundtrip: AttachmentRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(att, roundtrip);
+    assert!(
+        json.contains("relay_blob"),
+        "should contain relay_blob transport type"
+    );
+}
+
+#[test]
+fn attachment_transport_peer_seeded_roundtrip() {
+    let att = AttachmentRef {
+        content_id: ContentId::from_bytes(b"test"),
+        content_type: "application/zip".to_string(),
+        size: 300_000_000,
+        filename: None,
+        data: None,
+        transport: Some(AttachmentTransport::PeerSeeded {
+            blob_id: "deadbeef".repeat(8),
+            chunk_hashes: vec!["chunk0".to_string(), "chunk1".to_string()],
+            seeders: vec!["peer-a".to_string(), "peer-b".to_string()],
+            relay_fallback: "https://relay.example.com".to_string(),
+            blob_key: "a2V5Ynl0ZXM=".to_string(),
+        }),
+    };
+    let json = serde_json::to_string(&att).unwrap();
+    let roundtrip: AttachmentRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(att, roundtrip);
+    assert!(
+        json.contains("peer_seeded"),
+        "should contain peer_seeded transport type"
+    );
+}
+
+#[test]
+fn v1_attachment_ref_without_transport_deserialises_as_inline() {
+    // A v1 JSON payload (no `transport` field) should deserialise cleanly.
+    let v1_json = r#"{
+        "content_id": "dGVzdA",
+        "content_type": "image/jpeg",
+        "size": 1024,
+        "data": "aGVsbG8="
+    }"#;
+    let att: AttachmentRef = serde_json::from_str(v1_json).unwrap();
+    assert!(
+        att.transport.is_none(),
+        "v1 payload should have no transport"
+    );
+    assert_eq!(att.data, Some("aGVsbG8=".to_string()));
+}

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -17,6 +17,7 @@ fn envelope_roundtrips_via_json() {
             size: 128,
             filename: None,
             data: None,
+            transport: None,
         }],
     };
 

--- a/tests/relay_tests.rs
+++ b/tests/relay_tests.rs
@@ -111,6 +111,7 @@ async fn relay_expires_messages_after_ttl() {
         qos: tenet::relay::RelayQosConfig::default(),
         blob_max_chunk_bytes: 512 * 1024,
         blob_daily_quota_bytes: 500 * 1024 * 1024,
+        blob_ttl: Duration::from_secs(30 * 24 * 3600),
     })
     .await;
 
@@ -175,6 +176,7 @@ async fn relay_deduplicates_by_message_id() {
         qos: tenet::relay::RelayQosConfig::default(),
         blob_max_chunk_bytes: 512 * 1024,
         blob_daily_quota_bytes: 500 * 1024 * 1024,
+        blob_ttl: Duration::from_secs(30 * 24 * 3600),
     })
     .await;
 
@@ -240,6 +242,7 @@ async fn node_can_send_and_receive_through_relay() {
         qos: tenet::relay::RelayQosConfig::default(),
         blob_max_chunk_bytes: 512 * 1024,
         blob_daily_quota_bytes: 500 * 1024 * 1024,
+        blob_ttl: Duration::from_secs(30 * 24 * 3600),
     })
     .await;
 
@@ -334,6 +337,7 @@ fn test_relay_config() -> RelayConfig {
         qos: tenet::relay::RelayQosConfig::default(),
         blob_max_chunk_bytes: 512 * 1024,
         blob_daily_quota_bytes: 500 * 1024 * 1024,
+        blob_ttl: Duration::from_secs(30 * 24 * 3600),
     }
 }
 

--- a/tests/relay_tests.rs
+++ b/tests/relay_tests.rs
@@ -109,6 +109,8 @@ async fn relay_expires_messages_after_ttl() {
         log_sink: None,
         pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         qos: tenet::relay::RelayQosConfig::default(),
+        blob_max_chunk_bytes: 512 * 1024,
+        blob_daily_quota_bytes: 500 * 1024 * 1024,
     })
     .await;
 
@@ -171,6 +173,8 @@ async fn relay_deduplicates_by_message_id() {
         log_sink: None,
         pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         qos: tenet::relay::RelayQosConfig::default(),
+        blob_max_chunk_bytes: 512 * 1024,
+        blob_daily_quota_bytes: 500 * 1024 * 1024,
     })
     .await;
 
@@ -234,6 +238,8 @@ async fn node_can_send_and_receive_through_relay() {
         log_sink: None,
         pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         qos: tenet::relay::RelayQosConfig::default(),
+        blob_max_chunk_bytes: 512 * 1024,
+        blob_daily_quota_bytes: 500 * 1024 * 1024,
     })
     .await;
 
@@ -326,6 +332,8 @@ fn test_relay_config() -> RelayConfig {
         log_sink: None,
         pause_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         qos: tenet::relay::RelayQosConfig::default(),
+        blob_max_chunk_bytes: 512 * 1024,
+        blob_daily_quota_bytes: 500 * 1024 * 1024,
     }
 }
 

--- a/web/src/relay_dashboard.html
+++ b/web/src/relay_dashboard.html
@@ -17,8 +17,10 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;backgrou
 .card .label{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:#888;margin-bottom:4px}
 .card .value{font-size:26px;font-weight:600;font-variant-numeric:tabular-nums;color:#111}
 .card .value.hi{color:#2563eb}
+.card .value.warn{color:#d97706}
 .box{background:#fff;border:1px solid #e5e5e5;border-radius:6px;margin-bottom:20px;overflow:hidden}
-.box-title{padding:10px 16px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:#666;background:#fafafa;border-bottom:1px solid #e5e5e5}
+.box-title{padding:10px 16px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:#666;background:#fafafa;border-bottom:1px solid #e5e5e5;display:flex;align-items:center;justify-content:space-between}
+.box-title .count{font-weight:400;color:#999}
 table{width:100%;border-collapse:collapse}
 th{padding:8px 16px;text-align:left;font-size:11px;font-weight:500;text-transform:uppercase;letter-spacing:.05em;color:#999;background:#fafafa;border-bottom:1px solid #f0f0f0;white-space:nowrap}
 td{padding:9px 16px;font-size:13px;border-top:1px solid #f5f5f5;vertical-align:middle}
@@ -27,6 +29,7 @@ tr:hover td{background:#fafafa}
 .muted{color:#999}
 .bar-wrap{width:60px;height:4px;background:#eee;border-radius:2px;display:inline-block;vertical-align:middle;margin-left:8px}
 .bar-fill{height:100%;background:#2563eb;border-radius:2px}
+.bar-fill.warn{background:#d97706}
 .lat-row{padding:14px 16px;display:flex;gap:28px;align-items:center}
 .lat-item label{display:block;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:#999;margin-bottom:2px}
 .lat-item .n{font-size:20px;font-weight:600}
@@ -40,9 +43,13 @@ tr:hover td{background:#fafafa}
 .link-icon{font-size:13px;color:#2563eb;text-decoration:none;margin-left:6px}
 .link-icon:hover{text-decoration:underline}
 .badge{display:inline-block;padding:1px 7px;border-radius:10px;font-size:11px;background:#f0f4ff;color:#2563eb;font-weight:500}
+.badge.warn{background:#fef3c7;color:#92400e}
+.badge.ok{background:#dcfce7;color:#166534}
 .empty{padding:24px;text-align:center;color:#bbb;font-size:13px}
 .footer{text-align:center;color:#bbb;font-size:12px;margin-top:16px;margin-bottom:32px}
 .sender-row{font-size:12px;line-height:1.6}
+.uploader-list{display:flex;flex-wrap:wrap;gap:4px}
+.expiry-soon{color:#d97706;font-weight:500}
 @media(max-width:600px){.cards{grid-template-columns:repeat(2,1fr)}.lat-row{flex-wrap:wrap}}
 </style>
 </head>
@@ -55,8 +62,14 @@ tr:hover td{background:#fafafa}
   <div class="cards">
     <div class="card"><div class="label">Inboxes</div><div class="value" id="c-inboxes">&#x2014;</div></div>
     <div class="card"><div class="label">Queued</div><div class="value hi" id="c-queued">&#x2014;</div></div>
+    <div class="card"><div class="label">Blobs</div><div class="value" id="c-blobs">&#x2014;</div></div>
+    <div class="card"><div class="label">Blob Storage</div><div class="value" id="c-blob-bytes">&#x2014;</div></div>
+  </div>
+  <div class="cards">
     <div class="card"><div class="label">WebSockets</div><div class="value" id="c-ws">&#x2014;</div></div>
     <div class="card"><div class="label">Total Stored</div><div class="value" id="c-stored">&#x2014;</div></div>
+    <div class="card"><div class="label">Total Delivered</div><div class="value" id="c-delivered">&#x2014;</div></div>
+    <div class="card"><div class="label">Uptime</div><div class="value" id="c-uptime">&#x2014;</div></div>
   </div>
   <div class="box">
     <div class="box-title">Connected Clients</div>
@@ -65,6 +78,14 @@ tr:hover td{background:#fafafa}
   <div class="box">
     <div class="box-title">Inboxes</div>
     <div id="inboxes-body"></div>
+  </div>
+  <div class="box">
+    <div class="box-title"><span>Blob Store</span><span class="count" id="blob-store-count"></span></div>
+    <div id="blobs-body"></div>
+  </div>
+  <div class="box">
+    <div class="box-title">Blob Upload Quota (today)</div>
+    <div id="blob-quota-body"></div>
   </div>
   <div class="box">
     <div class="box-title">Delivery Latency</div>
@@ -76,9 +97,12 @@ tr:hover td{background:#fafafa}
 function fmtBytes(b){return b<1024?b+'B':b<1048576?(b/1024).toFixed(1)+'KB':(b/1048576).toFixed(2)+'MB'}
 function fmtDur(s){if(s<60)return s+'s';if(s<3600)return Math.floor(s/60)+'m '+pad(s%60)+'s';return Math.floor(s/3600)+'h '+pad(Math.floor((s%3600)/60))+'m'}
 function fmtMs(ms){if(ms<1000)return ms+'ms';const s=Math.floor(ms/1000);if(s<60)return(ms/1000).toFixed(1)+'s';if(s<3600)return Math.floor(s/60)+'m '+pad(s%60)+'s';return Math.floor(s/3600)+'h '+pad(Math.floor((s%3600)/60))+'m'}
+function fmtEpoch(ts){return new Date(ts*1000).toLocaleString()}
 function pad(n){return String(n).padStart(2,'0')}
 function fmtPeer(id){return id.length>20?id.slice(0,8)+'\u2026'+id.slice(-8):id}
+function fmtHash(h){return h.slice(0,8)+'\u2026'+h.slice(-8)}
 function set(id,v){const el=document.getElementById(id);if(el)el.textContent=v}
+function setHtml(id,v){const el=document.getElementById(id);if(el)el.innerHTML=v}
 function rateCell(m,h,d){
   return '<div class="del">'+
     '<span><b>'+m+'</b>/min</span>'+
@@ -86,14 +110,27 @@ function rateCell(m,h,d){
     '<span><b>'+d+'</b>/day</span>'+
   '</div>'
 }
+function quotaBar(used,total){
+  const pct=total>0?Math.min(100,Math.round(used/total*100)):0;
+  const cls=pct>=90?'warn':'';
+  return fmtBytes(used)+' / '+fmtBytes(total)+
+    ' <span class="bar-wrap"><div class="bar-fill '+cls+'" style="width:'+pct+'%"></div></span>'+
+    ' <span class="muted">('+pct+'%)</span>'
+}
 async function refresh(){
   let d;
   try{d=await fetch('/debug/stats').then(r=>r.json())}catch(e){set('footer','fetch failed \u2013 retrying');return}
-  set('uptime','up '+fmtDur(d.uptime_secs||0));
+
+  const uptime=fmtDur(d.uptime_secs||0);
+  set('uptime','up '+uptime);
+  set('c-uptime',uptime);
   set('c-inboxes',d.total_inboxes||0);
   set('c-queued',d.total_queued||0);
+  set('c-blobs',d.total_blobs||0);
+  set('c-blob-bytes',fmtBytes(d.total_blob_bytes||0));
   set('c-ws',d.ws_connections||0);
   set('c-stored',d.total_stored||0);
+  set('c-delivered',d.total_delivered||0);
 
   // Connected clients
   const clients=d.ws_clients||[];
@@ -136,6 +173,62 @@ async function refresh(){
         '<td class="muted">'+fmtDur(i.last_seen_secs)+' ago</td>'+
         '<td>'+rateCell(i.delivered_1m||0,i.delivered_1h||0,i.delivered_24h||0)+'</td>'+
         '<td>'+senderCell+'</td>'+
+        '</tr>';
+    }).join('')+'</tbody></table>'
+  }
+
+  // Blob store
+  const blobs=d.blobs||[];
+  const bb=document.getElementById('blobs-body');
+  const bcount=document.getElementById('blob-store-count');
+  if(bcount)bcount.textContent=blobs.length?blobs.length+' chunk'+(blobs.length===1?'':'s'):'';
+  if(!blobs.length){bb.innerHTML='<div class="empty">No blobs stored</div>'}
+  else{
+    const now=Math.floor(Date.now()/1000);
+    bb.innerHTML='<table><thead><tr>'+
+      '<th>Chunk Hash</th><th>Size</th><th>Refs</th><th>Uploaders</th><th>Uploaded</th><th>Expires</th>'+
+      '</tr></thead><tbody>'+
+    blobs.map(b=>{
+      const uploaders=b.uploaders||[];
+      const totalRefs=uploaders.length+(b.anon_refs||0);
+      const uploaderHtml=uploaders.length===0&&!b.anon_refs
+        ?'<span class="muted">\u2014</span>'
+        :'<div class="uploader-list">'+
+          uploaders.slice(0,3).map(u=>'<span class="badge mono">'+fmtPeer(u)+'</span>').join('')+
+          (uploaders.length>3?'<span class="muted">+'+(uploaders.length-3)+'</span>':'')+
+          (b.anon_refs?'<span class="badge">'+b.anon_refs+' anon</span>':'')+
+        '</div>';
+      const expiresIn=b.expires_in_secs||0;
+      const expirySoon=expiresIn<86400; // less than 1 day
+      const expiryHtml=expiresIn===0
+        ?'<span class="muted">expired</span>'
+        :'<span class="'+(expirySoon?'expiry-soon muted':'muted')+'">'+fmtDur(expiresIn)+' ('+fmtEpoch(b.expires_epoch)+')</span>';
+      return '<tr>'+
+        '<td class="mono">'+fmtHash(b.chunk_hash)+'</td>'+
+        '<td>'+fmtBytes(b.size_bytes)+'</td>'+
+        '<td><span class="badge '+(totalRefs>1?'ok':'')+'">'+totalRefs+'</span></td>'+
+        '<td>'+uploaderHtml+'</td>'+
+        '<td class="muted">'+fmtEpoch(b.uploaded_epoch)+'</td>'+
+        '<td>'+expiryHtml+'</td>'+
+        '</tr>';
+    }).join('')+'</tbody></table>'
+  }
+
+  // Blob upload quota
+  const quotas=d.blob_quotas||[];
+  const qb=document.getElementById('blob-quota-body');
+  if(!quotas.length){qb.innerHTML='<div class="empty">No blob uploads today</div>'}
+  else{
+    qb.innerHTML='<table><thead><tr>'+
+      '<th>Sender</th><th>Used Today</th><th>Quota</th>'+
+      '</tr></thead><tbody>'+
+    quotas.map(q=>{
+      const pct=q.quota_bytes>0?Math.min(100,Math.round(q.bytes_today/q.quota_bytes*100)):0;
+      const cls=pct>=90?'warn':'';
+      return '<tr>'+
+        '<td class="mono">'+fmtPeer(q.sender_id)+'</td>'+
+        '<td>'+quotaBar(q.bytes_today,q.quota_bytes)+'</td>'+
+        '<td class="muted">'+fmtBytes(q.quota_bytes)+'/day'+(pct>=90?' <span class="badge warn">'+pct+'%</span>':'')+'</td>'+
         '</tr>';
     }).join('')+'</tbody></table>'
   }


### PR DESCRIPTION
Implements the Chunked Relay Blob tier from docs/attachment_v2_plan.md.

## Protocol

Adds `AttachmentTransport` enum to `protocol.rs`:
- `Inline` (default, backwards-compatible v1 behaviour)
- `RelayBlob` — chunk hashes + relay URL + symmetric blob key, all
  encrypted inside the HPKE envelope so the relay sees only opaque chunks
- `PeerSeeded` — scaffold for Phase 2 peer-to-peer seeding

`AttachmentRef` gains a nullable `transport` field; senders without it
are treated as `Inline` for full backwards compatibility.

## Relay blob endpoints

Three new relay endpoints (`relay.rs`):
- `POST /blobs` — upload an encrypted chunk (body-limited to 512 KiB).
  Validates `SHA-256(data) == chunk_hash` before storing.  Per-sender
  daily upload quota enforced via `blob_daily_quota_bytes`.
- `GET /blobs/:hash` — download a chunk; no auth required (hash is
  self-authenticating ciphertext).
- `DELETE /blobs/:hash` — remove a stored chunk.

Two new `RelayConfig` fields: `blob_max_chunk_bytes` (default 512 KiB)
and `blob_daily_quota_bytes` (default 500 MiB/day).

## Client-side chunking (web_client)

`web_client/handlers/attachments.rs`:
- Files < 256 KiB → Inline tier (no change from v1).
- Files 256 KiB – 50 MiB → RelayBlob tier: file is split into 256 KiB
  chunks; each chunk is encrypted with ChaCha20Poly1305 using a random
  blob key and a per-chunk nonce derived as
  `SHA-256(blob_key || chunk_index_le64)[:12]`.  Chunks are uploaded to
  the configured relay; the blob manifest (key + hashes + relay URL) is
  stored in a new `blob_manifests` SQLite table.

`MAX_ATTACHMENT_SIZE` raised from 10 MiB to 50 MiB.

`build_attachment_refs` in `messages.rs` checks for a stored manifest
and populates `AttachmentTransport::RelayBlob` automatically.

## Storage

New `blob_manifests` table (content_hash, blob_key, relay_url,
chunk_hashes JSON, total_size, created_at) with `insert_blob_manifest`
and `get_blob_manifest` helpers.

## Tests

`tests/attachment_v2_tests.rs` — 13 tests covering upload/download
round-trip, 409 conflict, 400 hash mismatch, 413 oversized chunk, 429
quota exceeded, 204 delete, 404 not-found, and `AttachmentTransport`
JSON serialisation round-trips for all three transport variants including
v1 backwards-compat deserialisation.

https://claude.ai/code/session_019rPSM9PTvPxp9zaETqx7qZ