### PR TITLE
Add geohash and reverse geocoding dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ tokio-tungstenite = "0.21"
 futures-util = "0.3"
 tempfile = "3"
 qrcode = "0.14"
+geohash = "0.13"
+reverse_geocoder = "3"
 
 [dev-dependencies]
 tokio-tungstenite = "0.21"


### PR DESCRIPTION
## Summary
Added two new dependencies to support geospatial functionality: geohash for encoding/decoding geographic coordinates and reverse_geocoder for converting coordinates to human-readable addresses.

## Changes
- Added `geohash = "0.13"` dependency
- Added `reverse_geocoder = "3"` dependency

## Notes
These dependencies enable geolocation and geocoding features but no source code changes are included in this diff. Implementation of these features should follow in subsequent commits.

https://claude.ai/code/session_016YupWV5K325UEyTUWgstF3